### PR TITLE
fix(cli): rollup-plugin-html needs to be aware of the pathPrefix

### DIFF
--- a/.changeset/afraid-apricots-burn.md
+++ b/.changeset/afraid-apricots-burn.md
@@ -1,0 +1,5 @@
+---
+'@rocket/building-rollup': patch
+---
+
+Update rollup-plugin-html to support `absolutePathPrefix` option

--- a/.changeset/silent-coins-suffer.md
+++ b/.changeset/silent-coins-suffer.md
@@ -1,0 +1,5 @@
+---
+'@rocket/launch': patch
+---
+
+Do not double url social media images

--- a/.changeset/strange-years-wave.md
+++ b/.changeset/strange-years-wave.md
@@ -1,0 +1,5 @@
+---
+'@rocket/cli': patch
+---
+
+Pass prefix to rollup-plugin-html so assets can still be extracted

--- a/packages/building-rollup/package.json
+++ b/packages/building-rollup/package.json
@@ -54,7 +54,7 @@
     "@babel/preset-env": "^7.12.11",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-node-resolve": "^11.0.1",
-    "@web/rollup-plugin-html": "^1.3.3",
+    "@web/rollup-plugin-html": "^1.4.0",
     "@web/rollup-plugin-import-meta-assets": "^1.0.4",
     "@web/rollup-plugin-polyfills-loader": "^1.0.3",
     "browserslist": "^4.16.0",

--- a/packages/cli/src/RocketCli.js
+++ b/packages/cli/src/RocketCli.js
@@ -79,27 +79,11 @@ export class RocketCli {
       const rel = path.relative(process.cwd(), path.join(__dirname));
       const relCwdPathToConfig = path.join(rel, 'shared', '.eleventy.cjs');
       elev.setConfigPathOverride(relCwdPathToConfig);
-      // elev.setDryRun(true); // do not write to file system
       await elev.init();
 
       if (this.config.watch) {
         elev.watch();
       }
-
-      // // 11ty will bind this hook to itself
-      // const that = this;
-      // elev.config.filters['hook-for-rocket'] = async function hook(html, outputPath) {
-      //   // that.requestUpdate();
-      //   // const data = await this.getData();
-      //   // const { layout, title, inputPath } = data;
-      //   // const url = data.page.url;
-      //   // for (const plugin of that.plugins) {
-      //   //   if (typeof plugin.transformHtml === 'function') {
-      //   //     await plugin.transformHtml({ html, inputPath, outputPath, layout, title, url });
-      //   //   }
-      //   // }
-      //   return html;
-      // };
 
       this.eleventy = elev;
     }
@@ -135,12 +119,12 @@ export class RocketCli {
     if (this.config) {
       for (const plugin of this.config.plugins) {
         if (this.considerPlugin(plugin)) {
-          if (typeof plugin.setup === 'function') {
-            await plugin.setup({ config: this.config, argv: this.subArgv });
-          }
-
           if (typeof plugin.setupCommand === 'function') {
             this.config = plugin.setupCommand(this.config);
+          }
+
+          if (typeof plugin.setup === 'function') {
+            await plugin.setup({ config: this.config, argv: this.subArgv });
           }
         }
       }

--- a/packages/cli/test-node/RocketCli.e2e.test.js
+++ b/packages/cli/test-node/RocketCli.e2e.test.js
@@ -213,12 +213,16 @@ describe('RocketCli e2e', () => {
     });
     await execute();
 
-    const indexHtml = await readOutput('link/index.html', {
+    const linkHtml = await readOutput('link/index.html', {
       type: 'start',
     });
-    expect(indexHtml).to.equal(
+    expect(linkHtml).to.equal(
       ['<p><a href="../../">home</a></p>', '<p><a href="/">absolute home</a></p>'].join('\n'),
     );
+    const assetHtml = await readOutput('use-assets/index.html', {
+      type: 'start',
+    });
+    expect(assetHtml).to.equal('<link rel="stylesheet" href="/_merged_assets/some.css">');
   });
 
   it('can add a pathPrefix that will be used in the build command', async () => {
@@ -231,15 +235,21 @@ describe('RocketCli e2e', () => {
     });
     await execute();
 
-    const indexHtml = await readOutput('link/index.html', {
+    const linkHtml = await readOutput('link/index.html', {
       stripServiceWorker: true,
       stripToBody: true,
     });
-    expect(indexHtml).to.equal(
+    expect(linkHtml).to.equal(
       [
         '<p><a href="../../">home</a></p>',
         '<p><a href="/my-sub-folder/">absolute home</a></p>',
       ].join('\n'),
+    );
+    const assetHtml = await readOutput('use-assets/index.html', {
+      stripServiceWorker: true,
+    });
+    expect(assetHtml).to.equal(
+      '<html><head><link rel="stylesheet" href="../41297ffa.css">\n\n\n\n</head><body>\n\n</body></html>',
     );
   });
 });

--- a/packages/cli/test-node/e2e-fixtures/content/docs/_assets/some.css
+++ b/packages/cli/test-node/e2e-fixtures/content/docs/_assets/some.css
@@ -1,0 +1,1 @@
+body { background: green; }

--- a/packages/cli/test-node/e2e-fixtures/content/docs/use-assets.md
+++ b/packages/cli/test-node/e2e-fixtures/content/docs/use-assets.md
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+---
+
+<link rel="stylesheet" href="{{ '/_assets/some.css' | asset | url }}">

--- a/packages/launch/preset/_includes/partials/head-content.njk
+++ b/packages/launch/preset/_includes/partials/head-content.njk
@@ -26,7 +26,7 @@
 <meta property="og:title" content="{{ _pageTitle }}"/>
 <meta property="og:type" content="website"/>
 
-{% set _socialMediaImage = '/_assets/social-media-image.jpg' | asset | url %}
+{% set _socialMediaImage = '/_assets/social-media-image.jpg' | asset %}
 {% if socialMediaImage %}
   {% set _socialMediaImage = socialMediaImage %}
 {% endif %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1860,10 +1860,10 @@
   dependencies:
     glob "^7.0.0"
 
-"@web/rollup-plugin-html@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@web/rollup-plugin-html/-/rollup-plugin-html-1.3.3.tgz#366f1a889a93ef6a26afd227611deb23c52cd232"
-  integrity sha512-SSgL72jIV0+N68wafDW7M40yry2RfJfcZsVOhTlir+U6RdEz0hdQPXkf/o9sHxIxo3w0sgL6tN+q7VlHMOWQGw==
+"@web/rollup-plugin-html@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@web/rollup-plugin-html/-/rollup-plugin-html-1.4.0.tgz#bf94d1ee525e5f41dc527bbff9f7e24973a82238"
+  integrity sha512-AYOeRuNsPXQmNpxlJRFLlfVMm4EazXcJEz0bbVd6wKQVcEBM71kRboGfupxhoIkDcVyThefw9gETcMZ4ntUcTw==
   dependencies:
     "@web/parse5-utils" "^1.1.2"
     glob "^7.1.6"


### PR DESCRIPTION
## What I did

1. Make sure assets can still be found for building when using `pathPrefix`

Depends on a new release of rollup-plugin-html with https://github.com/modernweb-dev/web/pull/1179 included
