### PR TITLE
fix(check-html-links): read and parse with the same increased highWaterMark

### DIFF
--- a/.changeset/curly-poets-hunt.md
+++ b/.changeset/curly-poets-hunt.md
@@ -1,0 +1,5 @@
+---
+'check-html-links': patch
+---
+
+When reading bigger files, especially bigger files with all content on one line it could mean a read chunk is in the middle of a character. This can lead to strange symbols in the resulting string. The `hightWaterMark` is now increased from the node default of 16KB to 256KB. Additionally, the `hightWaterMark` is now synced for reading and parsing.

--- a/packages/check-html-links/src/validateFolder.js
+++ b/packages/check-html-links/src/validateFolder.js
@@ -15,10 +15,12 @@ import path from 'path';
 const require = createRequire(import.meta.url);
 const { SaxEventType, SAXParser } = saxWasm;
 
+const streamOptions = { highWaterMark: 256 * 1024 };
+
 const saxPath = require.resolve('sax-wasm/lib/sax-wasm.wasm');
 const saxWasmBuffer = fs.readFileSync(saxPath);
-const parserReferences = new SAXParser(SaxEventType.Attribute);
-const parserIds = new SAXParser(SaxEventType.Attribute /*, { highWaterMark: 256 * 1024 } */);
+const parserReferences = new SAXParser(SaxEventType.Attribute, streamOptions);
+const parserIds = new SAXParser(SaxEventType.Attribute, streamOptions);
 
 /** @type {Error[]} */
 let checkLocalFiles = [];
@@ -76,7 +78,7 @@ function extractReferences(htmlFilePath) {
   };
 
   return new Promise(resolve => {
-    const readable = fs.createReadStream(htmlFilePath);
+    const readable = fs.createReadStream(htmlFilePath, streamOptions);
     readable.on('data', chunk => {
       // @ts-expect-error
       parserReferences.write(chunk);
@@ -112,7 +114,7 @@ function idExists(filePath, id) {
   };
 
   return new Promise(resolve => {
-    const readable = fs.createReadStream(filePath);
+    const readable = fs.createReadStream(filePath, streamOptions);
     readable.on('data', chunk => {
       // @ts-expect-error
       parserIds.write(chunk);


### PR DESCRIPTION
## What I did

1. Increase highWaterMark
2. sync highWaterMark between reading stream and parsing stream

closes https://github.com/modernweb-dev/rocket/issues/48