### PR TITLE
resolves #54 introduce a ignoreLinkPatterns option

### DIFF
--- a/packages/check-html-links/package.json
+++ b/packages/check-html-links/package.json
@@ -33,7 +33,9 @@
   ],
   "dependencies": {
     "chalk": "^4.0.0",
+    "command-line-args": "^5.1.1",
     "glob": "^7.0.0",
+    "minimatch": "^3.0.4",
     "sax-wasm": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/check-html-links/src/CheckHtmlLinksCli.js
+++ b/packages/check-html-links/src/CheckHtmlLinksCli.js
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import path from 'path';
+import chalk from 'chalk';
+
+import commandLineArgs from 'command-line-args';
+import { validateFiles } from './validateFolder.js';
+import { formatErrors } from './formatErrors.js';
+import { listFiles } from './listFiles.js';
+
+export class CheckHtmlLinksCli {
+  /** @type {{dir: string?, ignoreLinkPatterns: string[]?}} */
+  argvConfig;
+
+  constructor({ argv } = { argv: undefined }) {
+    const mainDefinitions = [
+      { name: 'ignore-link-pattern', type: String, multiple: true },
+      { name: 'dir', type: String, defaultOption: true },
+    ];
+    const options = commandLineArgs(mainDefinitions, {
+      stopAtFirstUnknown: true,
+      argv,
+    });
+    this.argvConfig = {
+      dir: options.dir,
+      ignoreLinkPatterns: options['ignore-link-pattern'],
+    };
+  }
+
+  async run() {
+    const userRootDir = this.argvConfig.dir;
+    const rootDir = userRootDir ? path.resolve(userRootDir) : process.cwd();
+    const performanceStart = process.hrtime();
+
+    console.log('👀 Checking if all internal links work...');
+    const files = await listFiles('**/*.html', rootDir);
+
+    const filesOutput =
+      files.length == 0
+        ? '🧐 No files to check. Did you select the correct folder?'
+        : `🔥 Found a total of ${chalk.green.bold(files.length)} files to check!`;
+    console.log(filesOutput);
+
+    const { ignoreLinkPatterns } = this.argvConfig;
+
+    const { errors, numberLinks } = await validateFiles(files, rootDir, { ignoreLinkPatterns });
+
+    console.log(`🔗 Found a total of ${chalk.green.bold(numberLinks)} links to validate!\n`);
+
+    const performance = process.hrtime(performanceStart);
+    if (errors.length > 0) {
+      let referenceCount = 0;
+      for (const error of errors) {
+        referenceCount += error.usage.length;
+      }
+      const output = [
+        `❌ Found ${chalk.red.bold(
+          errors.length.toString(),
+        )} missing reference targets (used by ${referenceCount} links) while checking ${
+          files.length
+        } files:`,
+        ...formatErrors(errors)
+          .split('\n')
+          .map(line => `  ${line}`),
+        `Checking links duration: ${performance[0]}s ${performance[1] / 1000000}ms`,
+      ];
+      console.error(output.join('\n'));
+      process.exit(1);
+    } else {
+      console.log(
+        `✅ All internal links are valid. (executed in %ds %dms)`,
+        performance[0],
+        performance[1] / 1000000,
+      );
+    }
+  }
+}

--- a/packages/check-html-links/src/cli.js
+++ b/packages/check-html-links/src/cli.js
@@ -1,55 +1,6 @@
 #!/usr/bin/env node
 
-import path from 'path';
-import chalk from 'chalk';
-import { validateFiles } from './validateFolder.js';
-import { formatErrors } from './formatErrors.js';
-import { listFiles } from './listFiles.js';
+import { CheckHtmlLinksCli } from './CheckHtmlLinksCli.js';
 
-async function main() {
-  const userRootDir = process.argv[2];
-  const rootDir = userRootDir ? path.resolve(userRootDir) : process.cwd();
-  const performanceStart = process.hrtime();
-
-  console.log('👀 Checking if all internal links work...');
-  const files = await listFiles('**/*.html', rootDir);
-
-  const filesOutput =
-    files.length == 0
-      ? '🧐 No files to check. Did you select the correct folder?'
-      : `🔥 Found a total of ${chalk.green.bold(files.length)} files to check!`;
-  console.log(filesOutput);
-
-  const { errors, numberLinks } = await validateFiles(files, rootDir);
-
-  console.log(`🔗 Found a total of ${chalk.green.bold(numberLinks)} links to validate!\n`);
-
-  const performance = process.hrtime(performanceStart);
-  if (errors.length > 0) {
-    let referenceCount = 0;
-    for (const error of errors) {
-      referenceCount += error.usage.length;
-    }
-    const output = [
-      `❌ Found ${chalk.red.bold(
-        errors.length.toString(),
-      )} missing reference targets (used by ${referenceCount} links) while checking ${
-        files.length
-      } files:`,
-      ...formatErrors(errors)
-        .split('\n')
-        .map(line => `  ${line}`),
-      `Checking links duration: ${performance[0]}s ${performance[1] / 1000000}ms`,
-    ];
-    console.error(output.join('\n'));
-    process.exit(1);
-  } else {
-    console.log(
-      `✅ All internal links are valid. (executed in %ds %dms)`,
-      performance[0],
-      performance[1] / 1000000,
-    );
-  }
-}
-
-main();
+const cli = new CheckHtmlLinksCli();
+cli.run();

--- a/packages/check-html-links/test-node/fixtures/external-link/index.html
+++ b/packages/check-html-links/test-node/fixtures/external-link/index.html
@@ -1,0 +1,5 @@
+<!-- ignore known subsystems -->
+<a href="/docs/"></a>
+<a href="/developer/getting-started.html#js"></a>
+<a href="/developer/language-guides/"></a>
+<a href="/developer/javascript.html"></a>

--- a/packages/check-html-links/test-node/test-helpers.js
+++ b/packages/check-html-links/test-node/test-helpers.js
@@ -5,9 +5,9 @@ import { validateFolder } from 'check-html-links';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export async function execute(inPath) {
+export async function execute(inPath, opts) {
   const testDir = path.join(__dirname, inPath.split('/').join(path.sep));
-  const errors = await validateFolder(testDir);
+  const errors = await validateFolder(testDir, opts);
   return {
     cleanup: items => {
       const newItems = [];

--- a/packages/check-html-links/test-node/validateFolder.test.js
+++ b/packages/check-html-links/test-node/validateFolder.test.js
@@ -183,6 +183,13 @@ describe('validateFolder', () => {
     expect(cleanup(errors)).to.deep.equal([]);
   });
 
+  it('ignores arbitrary usages', async () => {
+    const { errors, cleanup } = await execute('fixtures/mailto', {
+      ignoreLinkPatterns: ['/docs/', '/developer/*'],
+    });
+    expect(cleanup(errors)).to.deep.equal([]);
+  });
+
   it('can handle img src', async () => {
     const { errors, cleanup } = await execute('fixtures/internal-images');
     expect(cleanup(errors)).to.deep.equal([

--- a/packages/check-html-links/types/main.d.ts
+++ b/packages/check-html-links/types/main.d.ts
@@ -25,3 +25,7 @@ export interface Error {
   onlyAnchorMissing: boolean;
   usage: Usage[];
 }
+
+interface Options {
+  ignoreLinkPatterns: string[] | null;
+}


### PR DESCRIPTION
## What I did

1. Add a `--ignore-link-pattern` option to the CLI
2. Add a `--dir` option  to the CLI

The following commands are equivalent:

```
$ npx check-html-links _site
```

```
$ npx check-html-links --dir _site
```

3. Introduce a options object to the `validateFolder` and `validateFiles` functions
4. Convert link patterns (glob syntax) to regular expressions using `minimatch`
5. Pass a `ignoreUsage` function to the `resolveLinks` function to decide if a usage should be ignored or not

If we want to offer more flexibility, the `ignoreUsage` function (`function(Usage): boolean`) could be defined by the user.