### PR TITLE
fix: use class node api of check-html-links in rocket

### DIFF
--- a/.changeset/nice-parrots-punch.md
+++ b/.changeset/nice-parrots-punch.md
@@ -1,0 +1,5 @@
+---
+'@rocket/cli': patch
+---
+
+Use class-based node API of check-html-links

--- a/.changeset/pink-melons-matter.md
+++ b/.changeset/pink-melons-matter.md
@@ -1,0 +1,11 @@
+---
+'check-html-links': minor
+---
+
+Uses a class for the CLI and adding the following options:
+- `--root-dir` the root directory to serve files from. Defaults to the current working directory 
+- `--ignore-link-pattern` do not check links matching the pattern
+- `--continue-on-error` if present it will not exit with an error code - useful while writing or for temporary passing a ci
+
+BREAKING CHANGE:
+- Exists with an error code if a broken link is found

--- a/docs/docs/tools/check-html-links.md
+++ b/docs/docs/tools/check-html-links.md
@@ -1,6 +1,16 @@
 # Tools >> Check HTML Links ||30
 
+```js
+import '@rocket/launch/inline-notification/inline-notification.js';
+```
+
 A fast checker for broken links/references in HTML.
+
+<inline-notification type="tip">
+
+Read the [Introducing Check HTMl Links - no more bad links](../../blog/introducing-check-html-links.md) Blog post to find out how it came to be and how it works.
+
+</inline-notification>
 
 ## Features
 
@@ -16,10 +26,25 @@ A fast checker for broken links/references in HTML.
 npm i -D check-html-links
 ```
 
-## Usage
+## CLI flags
 
-```
+| Name                | Type    | Description                                                                                         |
+| ------------------- | ------- | --------------------------------------------------------------------------------------------------- |
+| root-dir            | string  | the root directory to serve files from. Defaults to the current working directory                   |
+| ignore-link-pattern | string  | do not check links matching the pattern                                                             |
+| continue-on-error   | boolean | if present it will not exit with an error code - useful while writing or for temporary passing a ci |
+
+## Usage Examples
+
+```bash
+# check a folder _site
 npx check-html-links _site
+
+# ignore all links like <a href="/users/123">
+npx check-html-links _site --ignore-link-pattern "/users/*" "/users/**/*"
+
+# ignore all links like <a href="/users/123"> & <a href="/users/123/details">
+npx check-html-links _site --ignore-link-pattern "/users/*" "/users/**/*"
 ```
 
 ## Example Output

--- a/packages/check-html-links/index.js
+++ b/packages/check-html-links/index.js
@@ -1,2 +1,3 @@
 export { validateFolder } from './src/validateFolder.js';
 export { formatErrors } from './src/formatErrors.js';
+export { CheckHtmlLinksCli } from './src/CheckHtmlLinksCli.js';

--- a/packages/check-html-links/src/CheckHtmlLinksCli.js
+++ b/packages/check-html-links/src/CheckHtmlLinksCli.js
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
+/** @typedef {import('../types/main').CheckHtmlLinksCliOptions} CheckHtmlLinksCliOptions */
+
 import path from 'path';
 import chalk from 'chalk';
 
@@ -9,26 +11,39 @@ import { formatErrors } from './formatErrors.js';
 import { listFiles } from './listFiles.js';
 
 export class CheckHtmlLinksCli {
-  /** @type {{dir: string?, ignoreLinkPatterns: string[]?}} */
-  argvConfig;
+  /** @type {CheckHtmlLinksCliOptions} */
+  options;
 
   constructor({ argv } = { argv: undefined }) {
     const mainDefinitions = [
       { name: 'ignore-link-pattern', type: String, multiple: true },
-      { name: 'dir', type: String, defaultOption: true },
+      { name: 'root-dir', type: String, defaultOption: true },
+      { name: 'continue-on-error', type: Boolean, defaultOption: false },
     ];
     const options = commandLineArgs(mainDefinitions, {
       stopAtFirstUnknown: true,
       argv,
     });
-    this.argvConfig = {
-      dir: options.dir,
+    this.options = {
+      printOnError: true,
+      continueOnError: options['continue-on-error'],
+      rootDir: options['root-dir'],
       ignoreLinkPatterns: options['ignore-link-pattern'],
     };
   }
 
+  /**
+   * @param {Partial<CheckHtmlLinksCliOptions>} newOptions
+   */
+  setOptions(newOptions) {
+    this.options = {
+      ...this.options,
+      ...newOptions,
+    };
+  }
+
   async run() {
-    const userRootDir = this.argvConfig.dir;
+    const { ignoreLinkPatterns, rootDir: userRootDir } = this.options;
     const rootDir = userRootDir ? path.resolve(userRootDir) : process.cwd();
     const performanceStart = process.hrtime();
 
@@ -41,19 +56,20 @@ export class CheckHtmlLinksCli {
         : `🔥 Found a total of ${chalk.green.bold(files.length)} files to check!`;
     console.log(filesOutput);
 
-    const { ignoreLinkPatterns } = this.argvConfig;
-
     const { errors, numberLinks } = await validateFiles(files, rootDir, { ignoreLinkPatterns });
 
     console.log(`🔗 Found a total of ${chalk.green.bold(numberLinks)} links to validate!\n`);
 
     const performance = process.hrtime(performanceStart);
+    /** @type {string[]} */
+    let output = [];
+    let message = '';
     if (errors.length > 0) {
       let referenceCount = 0;
       for (const error of errors) {
         referenceCount += error.usage.length;
       }
-      const output = [
+      output = [
         `❌ Found ${chalk.red.bold(
           errors.length.toString(),
         )} missing reference targets (used by ${referenceCount} links) while checking ${
@@ -64,14 +80,21 @@ export class CheckHtmlLinksCli {
           .map(line => `  ${line}`),
         `Checking links duration: ${performance[0]}s ${performance[1] / 1000000}ms`,
       ];
-      console.error(output.join('\n'));
-      process.exit(1);
+      message = output.join('\n');
+      if (this.options.printOnError === true) {
+        console.error(message);
+      }
+      if (this.options.continueOnError === false) {
+        process.exit(1);
+      }
     } else {
       console.log(
-        `✅ All internal links are valid. (executed in %ds %dms)`,
-        performance[0],
-        performance[1] / 1000000,
+        `✅ All internal links are valid. (executed in ${performance[0]}s ${
+          performance[1] / 1000000
+        }ms)`,
       );
     }
+
+    return { errors, message };
   }
 }

--- a/packages/check-html-links/src/validateFolder.js
+++ b/packages/check-html-links/src/validateFolder.js
@@ -187,7 +187,7 @@ function getValueAndAnchor(inValue) {
  * @param {object} options
  * @param {string} options.htmlFilePath
  * @param {string} options.rootDir
- * @param {function(Usage): boolean} options.ignoreUsage
+ * @param {function(string): boolean} options.ignoreUsage
  */
 async function resolveLinks(links, { htmlFilePath, rootDir, ignoreUsage }) {
   for (const hrefObj of links) {
@@ -204,7 +204,7 @@ async function resolveLinks(links, { htmlFilePath, rootDir, ignoreUsage }) {
 
     let valueFile = value.endsWith('/') ? path.join(value, 'index.html') : value;
 
-    if (ignoreUsage(usageObj)) {
+    if (ignoreUsage(value)) {
       // ignore
     } else if (value.includes('mailto:')) {
       // ignore for now - could add a check to validate if the email address is valid
@@ -281,9 +281,9 @@ export async function validateFiles(files, rootDir, opts) {
     ? opts.ignoreLinkPatterns?.map(pattern => minimatch.makeRe(pattern))
     : null;
 
-  /** @type {function(Usage): boolean} */
+  /** @type {function(string): boolean} */
   const ignoreUsage = ignoreLinkPatternRegExps
-    ? usage => !!ignoreLinkPatternRegExps.find(regExp => usage.value.match(regExp))
+    ? usage => !!ignoreLinkPatternRegExps.find(regExp => usage.match(regExp))
     : () => false;
 
   for (const htmlFilePath of files) {

--- a/packages/check-html-links/test-node/fixtures/internal-link-ignore/index.html
+++ b/packages/check-html-links/test-node/fixtures/internal-link-ignore/index.html
@@ -1,0 +1,8 @@
+<a href="/absolute/index.html"></a>
+<a href="./relative/index.html"></a>
+<a href="./relative/subfolder/index.html"></a>
+
+<!-- valid -->
+<a href="./page.html"></a>
+<a href=" ./page.html "></a>
+<a href=" /page.html "></a>

--- a/packages/check-html-links/test-node/validateFolder.test.js
+++ b/packages/check-html-links/test-node/validateFolder.test.js
@@ -183,11 +183,26 @@ describe('validateFolder', () => {
     expect(cleanup(errors)).to.deep.equal([]);
   });
 
-  it('ignores arbitrary usages', async () => {
-    const { errors, cleanup } = await execute('fixtures/mailto', {
-      ignoreLinkPatterns: ['/docs/', '/developer/*'],
+  it('ignoring a folder', async () => {
+    const { errors, cleanup } = await execute('fixtures/internal-link-ignore', {
+      ignoreLinkPatterns: ['./relative/*', './relative/**/*'],
     });
-    expect(cleanup(errors)).to.deep.equal([]);
+    expect(cleanup(errors)).to.deep.equal([
+      {
+        filePath: 'fixtures/internal-link-ignore/absolute/index.html',
+        onlyAnchorMissing: false,
+        usage: [
+          {
+            anchor: '',
+            attribute: 'href',
+            character: 9,
+            file: 'fixtures/internal-link-ignore/index.html',
+            line: 0,
+            value: '/absolute/index.html',
+          },
+        ],
+      },
+    ]);
   });
 
   it('can handle img src', async () => {

--- a/packages/check-html-links/types/main.d.ts
+++ b/packages/check-html-links/types/main.d.ts
@@ -29,3 +29,10 @@ export interface Error {
 interface Options {
   ignoreLinkPatterns: string[] | null;
 }
+
+export interface CheckHtmlLinksCliOptions {
+  printOnError: boolean;
+  rootDir: string;
+  ignoreLinkPatterns: string[] | null;
+  continueOnError: boolean;
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,7 @@
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.1",
     "fs-extra": "^9.0.1",
+    "micromatch": "^4.0.2",
     "plugins-manager": "^0.2.0",
     "utf8": "^3.0.0"
   },


### PR DESCRIPTION
## What I did

1. Rocket: Use class based node api of check-html-links
2. Release of ignore links pattern & add continueOnError
