### PR TITLE
feat: Allow overlay query modification in Drawer (#73)

### DIFF
--- a/packages/drawer/src/RocketDrawer.js
+++ b/packages/drawer/src/RocketDrawer.js
@@ -18,6 +18,7 @@ export class RocketDrawer extends OverlayMixin(LitElement) {
     return {
       useOverlay: { type: Boolean, reflect: true },
       useOverlayMediaQuery: { type: String },
+      mediaMatcher: { type: Object },
     };
   }
 
@@ -89,6 +90,20 @@ export class RocketDrawer extends OverlayMixin(LitElement) {
         }
       }
     }
+    if (changedProperties.has('useOverlayMediaQuery')) {
+      this.mediaMatcher.removeEventListener('change', this.onMatchMedia);
+
+      this.mediaMatcher = window.matchMedia(this.useOverlayMediaQuery);
+      this.mediaMatcher.addEventListener('change', this.onMatchMedia);
+      this.useOverlay = !!this.mediaMatcher.matches;
+    }
+  }
+
+  /**
+   * @param { MediaQueryListEvent } query
+   */
+  onMatchMedia(query) {
+    this.useOverlay = !!query.matches;
   }
 
   _setupOpenCloseListeners() {
@@ -118,10 +133,14 @@ export class RocketDrawer extends OverlayMixin(LitElement) {
 
     this.__toggle = this.__toggle.bind(this);
 
+    this.onMatchMedia = this.onMatchMedia.bind(this);
     this.onGestureStart = this.onGestureStart.bind(this);
     this.onGestureMove = this.onGestureMove.bind(this);
     this.onGestureEnd = this.onGestureEnd.bind(this);
     this.updateFromTouch = this.updateFromTouch.bind(this);
+
+    this.mediaMatcher = window.matchMedia(this.useOverlayMediaQuery);
+    this.mediaMatcher.addEventListener('change', this.onMatchMedia);
 
     this._startX = 0;
     this._currentX = 0;
@@ -133,10 +152,7 @@ export class RocketDrawer extends OverlayMixin(LitElement) {
 
   connectedCallback() {
     super.connectedCallback();
-    this.useOverlay = !!window.matchMedia(this.useOverlayMediaQuery).matches;
-    window.matchMedia(this.useOverlayMediaQuery).addListener(query => {
-      this.useOverlay = !!query.matches;
-    });
+    this.useOverlay = !!this.mediaMatcher.matches;
   }
 
   render() {


### PR DESCRIPTION
> Rebase of https://github.com/modernweb-dev/rocket/pull/76

## What I did

1. Added possibility to declare a custom media query for the `useOverlay` switch in RocketDrawer.
2. Switched from a [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#methods) addListener method to addEventListener

## Usage:

```js
<rocket-drawer useOverlayMediaQuery="(max-width: 768px)">
```
