### PR TITLE
fix: add missing main entry to the packages

### DIFF
--- a/.changeset/hip-eels-remain.md
+++ b/.changeset/hip-eels-remain.md
@@ -1,0 +1,12 @@
+---
+'@rocket/building-rollup': patch
+'check-html-links': patch
+'@rocket/cli': patch
+'@rocket/core': patch
+'@mdjs/mdjs-preview': patch
+'@mdjs/mdjs-story': patch
+'plugins-manager': patch
+'@rocket/search': patch
+---
+
+fix: add missing main entry to the packages

--- a/packages/building-rollup/package.json
+++ b/packages/building-rollup/package.json
@@ -14,6 +14,7 @@
   "author": "Modern Web <hello@modern-web.dev> (https://modern-web.dev/)",
   "homepage": "https://rocket.modern-web.dev/docs/tools/building-rollup/",
   "type": "module",
+  "main": "./index.js",
   "exports": {
     ".": "./index.js"
   },

--- a/packages/check-html-links/package.json
+++ b/packages/check-html-links/package.json
@@ -17,6 +17,7 @@
     "check-html-links": "src/cli.js"
   },
   "type": "module",
+  "main": "./index.js",
   "exports": {
     ".": "./index.js"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
     "rocket": "src/cli.js"
   },
   "type": "module",
+  "main": "./index.cjs",
   "exports": {
     ".": {
       "require": "./index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
   "author": "Modern Web <hello@modern-web.dev> (https://modern-web.dev/)",
   "homepage": "https://rocket.modern-web.dev/",
   "type": "module",
+  "main": "./dist/title.cjs",
   "exports": {
     "./title": {
       "require": "./dist/title.cjs",

--- a/packages/mdjs-preview/package.json
+++ b/packages/mdjs-preview/package.json
@@ -13,6 +13,7 @@
   },
   "author": "Modern Web <hello@modern-web.dev> (https://modern-web.dev/)",
   "homepage": "https://rocket.modern-web.dev/docs/markdown-javascript/preview/",
+  "main": "./index.js",
   "type": "module",
   "exports": {
     ".": "./index.js",

--- a/packages/mdjs-story/package.json
+++ b/packages/mdjs-story/package.json
@@ -13,6 +13,7 @@
   },
   "author": "Modern Web <hello@modern-web.dev> (https://modern-web.dev/)",
   "homepage": "https://rocket.modern-web.dev/docs/markdown-javascript/story/",
+  "main": "./index.js",
   "type": "module",
   "exports": {
     ".": "./index.js",

--- a/packages/plugins-manager/package.json
+++ b/packages/plugins-manager/package.json
@@ -14,6 +14,7 @@
   "author": "Modern Web <hello@modern-web.dev> (https://modern-web.dev/)",
   "homepage": "https://rocket.modern-web.dev/docs/tools/plugins-manager/",
   "type": "module",
+  "main": "./dist/index.cjs",
   "exports": {
     ".": {
       "require": "./dist/index.cjs",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -14,6 +14,7 @@
   "author": "Modern Web <hello@modern-web.dev> (https://modern-web.dev/)",
   "homepage": "https://rocket.modern-web.dev/docs/presets/search/",
   "type": "module",
+  "main": "./node.js",
   "exports": {
     ".": "./node.js",
     "./node": "./node.js",


### PR DESCRIPTION
This allows the tools to work properly. For example, eslint-plugin-import, TypeScript LSP hyperclick, and many other tools rely on main.

## What I did

1. add missing main entry to the packages