### PR TITLE
feat(eleventy-rocket-nav): support dynamically created content

### DIFF
--- a/.changeset/tasty-baboons-argue.md
+++ b/.changeset/tasty-baboons-argue.md
@@ -1,0 +1,8 @@
+---
+'@rocket/eleventy-rocket-nav': minor
+---
+
+To support dynamically created content to be part of the anchor navigation of the page we now analyze the final html output instead of `entry.templateContent`.
+
+BREAKING CHANGE:
+- only add anchors for the currently active pages (before it added anchor for every page)

--- a/packages/eleventy-rocket-nav/.eleventy.js
+++ b/packages/eleventy-rocket-nav/.eleventy.js
@@ -1,4 +1,5 @@
 const RocketNav = require('./eleventy-rocket-nav');
+const { addPageAnchors } = require('./src/addPageAnchors.js');
 
 // export the configuration function for plugin
 module.exports = function (eleventyConfig) {
@@ -7,6 +8,10 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addNunjucksFilter('rocketNavBreadcrumb', RocketNav.findBreadcrumbEntries);
   eleventyConfig.addNunjucksFilter('rocketNavToHtml', function (pages, options) {
     return RocketNav.toHtml.call(eleventyConfig, pages, options);
+  });
+  eleventyConfig.addTransform('rocket-nav-add-page-anchors', async function (content) {
+    const newContent = await addPageAnchors(content);
+    return newContent;
   });
 };
 

--- a/packages/eleventy-rocket-nav/package.json
+++ b/packages/eleventy-rocket-nav/package.json
@@ -13,7 +13,7 @@
   },
   "main": ".eleventy.js",
   "scripts": {
-    "test": "mocha test-node/**/*.test.js test-node/*.test.js",
+    "test": "mocha test-node/**/*.test.js test-node/*.test.js --timeout 5000",
     "test:watch": "mocha test-node/**/*.test.js test-node/*.test.js --watch"
   },
   "files": [

--- a/packages/eleventy-rocket-nav/src/addPageAnchors.js
+++ b/packages/eleventy-rocket-nav/src/addPageAnchors.js
@@ -1,0 +1,136 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+const fs = require('fs');
+const { SaxEventType, SAXParser } = require('sax-wasm');
+
+const saxPath = require.resolve('sax-wasm/lib/sax-wasm.wasm');
+const saxWasmBuffer = fs.readFileSync(saxPath);
+
+/** @typedef {import('../types').Heading} Heading */
+
+/** @typedef {import('sax-wasm').Text} Text */
+/** @typedef {import('sax-wasm').Tag} Tag */
+/** @typedef {import('sax-wasm').Position} Position */
+
+// Instantiate
+const parser = new SAXParser(
+  SaxEventType.CloseTag | SaxEventType.Comment,
+  { highWaterMark: 256 * 1024 }, // 256k chunks
+);
+
+/**
+ * @param {object} options
+ * @param {string} options.content
+ * @param {Position} options.start
+ * @param {Position} options.end
+ * @param {string} options.insert
+ */
+function removeBetween({ content, start, end, insert = '' }) {
+  const lines = content.split('\n');
+  const i = start.line;
+  const line = lines[i];
+  const upToChange = line.slice(0, start.character - 1);
+  const afterChange = line.slice(end.character + 2);
+
+  lines[i] = `${upToChange}${insert}${afterChange}`;
+  return lines.join('\n');
+}
+
+/**
+ * @param {Tag} data
+ * @param {string} name
+ */
+function getAttribute(data, name) {
+  if (data.attributes) {
+    const { attributes } = data;
+    const foundIndex = attributes.findIndex(entry => entry.name.value === name);
+    if (foundIndex !== -1) {
+      return attributes[foundIndex].value.value;
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {Tag} data
+ */
+function getText(data) {
+  if (data.textNodes) {
+    return data.textNodes.map(textNode => textNode.value).join('');
+  }
+  return null;
+}
+
+/**
+ * @param {string} html
+ */
+function getHeadingsOfHtml(html) {
+  /** @type {Heading[]} */
+  const headings = [];
+  /** @type {Text} */
+  let insertPoint;
+  parser.eventHandler = (ev, _data) => {
+    if (ev === SaxEventType.Comment) {
+      const data = /** @type {Text} */ (/** @type {any} */ (_data));
+      // NOTE: we NEED to access data internal value so sax-wasm does not reuse it's value
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const tmp = data.start.line + data.end.line;
+      if (data.value.trim() === 'ADD PAGE ANCHORS' || data.value.trim() === '-->ADD PAGE ANCHORS') {
+        insertPoint = data;
+      }
+    }
+
+    if (ev === SaxEventType.CloseTag) {
+      const data = /** @type {Tag} */ (/** @type {any} */ (_data));
+      if (data.name === 'h2') {
+        const id = getAttribute(data, 'id');
+        const text = getText(data);
+        if (id && text) {
+          headings.push({ text, id });
+        }
+      }
+    }
+  };
+  parser.write(Buffer.from(html, 'utf8'));
+  parser.end();
+
+  // @ts-ignore
+  return { headings, insertPoint };
+}
+
+let isSetup = false;
+
+/**
+ * @param {string} content
+ */
+async function addPageAnchors(content) {
+  if (!isSetup) {
+    await parser.prepareWasm(saxWasmBuffer);
+    isSetup = true;
+  }
+
+  const { headings, insertPoint } = getHeadingsOfHtml(content);
+  const pageAnchorsHtml = [];
+  if (headings.length > 0) {
+    pageAnchorsHtml.push('<ul>');
+    for (const heading of headings) {
+      pageAnchorsHtml.push('  <li class="menu-item anchor">');
+      pageAnchorsHtml.push(`    <a href="#${heading.id}" class="anchor">${heading.text}</a>`);
+      pageAnchorsHtml.push('  </li>');
+    }
+    pageAnchorsHtml.push('</ul>');
+  }
+
+  if (insertPoint) {
+    return removeBetween({
+      content,
+      start: insertPoint.start,
+      end: insertPoint.end,
+      insert: pageAnchorsHtml.join('\n'),
+    });
+  }
+  return content;
+}
+
+module.exports = {
+  addPageAnchors,
+};

--- a/packages/eleventy-rocket-nav/test-node/addPageAnchors.test.js
+++ b/packages/eleventy-rocket-nav/test-node/addPageAnchors.test.js
@@ -1,0 +1,32 @@
+const { expect } = require('chai');
+const prettier = require('prettier');
+const { addPageAnchors } = require('../src/addPageAnchors.js');
+
+const format = code => prettier.format(code, { parser: 'html' }).trim();
+
+describe('addPageAnchors', () => {
+  it('finds and adds anchors for each h2 as an unordered list', async () => {
+    const input = [
+      '<body>',
+      '  <!-- ADD PAGE ANCHORS -->',
+      '  <div id="content">',
+      '    <h2 id="first">👉 First Headline</h2>',
+      '  </div>',
+      '</body>',
+    ].join('\n');
+    const expected = [
+      '<body>',
+      '  <ul>',
+      '    <li class="menu-item anchor">',
+      '      <a href="#first" class="anchor">👉 First Headline</a>',
+      '    </li>',
+      '  </ul>',
+      '  <div id="content">',
+      '    <h2 id="first">👉 First Headline</h2>',
+      '  </div>',
+      '</body>',
+    ].join('\n');
+    const result = await addPageAnchors(input);
+    expect(format(result)).to.deep.equal(expected);
+  });
+});

--- a/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/.eleventy.js
+++ b/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/.eleventy.js
@@ -1,0 +1,5 @@
+const eleventyNavigationPlugin = require('@rocket/eleventy-rocket-nav');
+
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(eleventyNavigationPlugin);
+};

--- a/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/_data/layout.cjs
+++ b/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/_data/layout.cjs
@@ -1,0 +1,1 @@
+module.exports = 'layout.njk';

--- a/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/_includes/layout.njk
+++ b/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/_includes/layout.njk
@@ -1,0 +1,9 @@
+<body>
+  {{ collections.all | rocketNav | rocketNavToHtml({
+    listItemClass: "menu-item",
+    activeListItemClass: "current",
+    activeKey: eleventyNavigation.key
+  }) | safe }}
+
+  {{ content | safe }}
+</body>

--- a/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/bats.md
+++ b/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/bats.md
@@ -1,0 +1,9 @@
+---
+title: Bats
+eleventyNavigation:
+  key: Bats
+  parent: Mammals
+  order: 2
+---
+
+🦇 can fly.

--- a/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/humans.md
+++ b/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/humans.md
@@ -1,0 +1,12 @@
+---
+title: Humans
+eleventyNavigation:
+  key: Humans
+  parent: Mammals
+  order: 1
+---
+
+<h2 id="anatomy">Anatomy</h2>
+<p>Has arms.</p>
+<h2 id="age">📖 Age</h2>
+<p>Up to 130 years.</p>

--- a/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/mammals.md
+++ b/packages/eleventy-rocket-nav/test-node/fixtures/three-pages/mammals.md
@@ -1,0 +1,7 @@
+---
+title: Mammals
+eleventyNavigation:
+  key: Mammals
+---
+
+Mammals need air.

--- a/packages/eleventy-rocket-nav/test-node/integration.test.js
+++ b/packages/eleventy-rocket-nav/test-node/integration.test.js
@@ -1,0 +1,96 @@
+const path = require('path');
+const fs = require('fs-extra');
+const { expect } = require('chai');
+const Eleventy = require('@11ty/eleventy');
+const TemplateConfig = require('@11ty/eleventy/src/TemplateConfig');
+const prettier = require('prettier');
+
+async function execute(fixtureDir) {
+  const relPath = path.relative(process.cwd(), __dirname);
+  const relativeInputPath = path.join(relPath, fixtureDir.split('/').join(path.sep));
+  const relativeOutputPath = path.join(relPath, 'fixtures', '__output');
+  const relativeConfigPath = path.join(relativeInputPath, '.eleventy.js');
+
+  await fs.emptyDir(relativeOutputPath);
+
+  const elev = new Eleventy(relativeInputPath, relativeOutputPath);
+  const config = new TemplateConfig(null, relativeConfigPath);
+  elev.config = config.getConfig();
+  elev.setConfigPathOverride(relativeConfigPath);
+  elev.resetConfig();
+
+  await elev.init();
+  await elev.write();
+  return {
+    readOutput: async readPath => {
+      const relativeReadPath = path.join(relativeOutputPath, readPath);
+      let text = await fs.promises.readFile(relativeReadPath);
+      text = text.toString();
+      text = prettier.format(text, { parser: 'html', printWidth: 100 });
+      return text.trim();
+    },
+  };
+}
+
+describe('eleventy-rocket-nav', () => {
+  it('renders a menu with anchors for h2 content', async () => {
+    const { readOutput } = await execute('fixtures/three-pages');
+
+    const bats = await readOutput('bats/index.html');
+    expect(bats).to.deep.equal(
+      [
+        '<body>',
+        '  <ul>',
+        '    <li class="menu-item active">',
+        '      <a href="/mammals/">Mammals</a>',
+        '      <ul>',
+        '        <li class="menu-item">',
+        '          <a href="/humans/">Humans</a>',
+        '        </li>',
+        '        <li class="menu-item current">',
+        '          <a href="/bats/">Bats</a>',
+        '        </li>',
+        '      </ul>',
+        '    </li>',
+        '  </ul>',
+        '',
+        '  <p>🦇 can fly.</p>',
+        '</body>',
+      ].join('\n'),
+    );
+
+    const humans = await readOutput('humans/index.html');
+    expect(humans).to.deep.equal(
+      [
+        '<body>',
+        '  <ul>',
+        '    <li class="menu-item active">',
+        '      <a href="/mammals/">Mammals</a>',
+        '      <ul>',
+        '        <li class="menu-item current">',
+        '          <a href="/humans/">Humans</a>',
+        '          <ul>',
+        '            <li class="menu-item anchor">',
+        '              <a href="#anatomy" class="anchor">Anatomy</a>',
+        '            </li>',
+        '            <li class="menu-item anchor">',
+        '              <a href="#age" class="anchor">📖 Age</a>',
+        '            </li>',
+        '          </ul>',
+        '        </li>',
+        '        <li class="menu-item">',
+        '          <a href="/bats/">Bats</a>',
+        '        </li>',
+        '      </ul>',
+        '    </li>',
+        '  </ul>',
+        '',
+        '  <h2 id="anatomy">Anatomy</h2>',
+        '  <p>Has arms.</p>',
+        '  <h2 id="age">📖 Age</h2>',
+        '  <p>Up to 130 years.</p>',
+        '</body>',
+      ].join('\n'),
+    );
+  });
+});


### PR DESCRIPTION
## What I did

1. To support dynamically created content to be part of the anchor navigation of the page we now analyze the final html output instead of `entry.templateContent`.

BREAKING CHANGE:
- only add anchors for the currently active pages (before it added anchor for every page)

closes: https://github.com/modernweb-dev/rocket/issues/42