### PR TITLE
chore: generalize label & add alt when no img

### DIFF
--- a/.changeset/chilled-turkeys-help.md
+++ b/.changeset/chilled-turkeys-help.md
@@ -1,0 +1,5 @@
+---
+'@rocket/search': patch
+---
+
+chore: generalize label & add alt when no img

--- a/packages/search/src/RocketSearch.js
+++ b/packages/search/src/RocketSearch.js
@@ -112,7 +112,7 @@ export class RocketSearch extends ScopedElementsMixin(LitElement) {
     return html`
       <rocket-search-combobox
         name="combo"
-        label="Rocket Search"
+        label="Search"
         @input=${ev => {
           this.search = ev.target.value;
         }}

--- a/packages/search/src/RocketSearchOption.js
+++ b/packages/search/src/RocketSearchOption.js
@@ -103,7 +103,7 @@ export class RocketSearchOption extends LinkMixin(LionOption) {
 
   render() {
     return html`
-      <img class="icon" src=${getIcon(this.section)} />
+      <img class="icon" src=${getIcon(this.section)} alt=${this.section} />
       <div class="choice-field__label">
         <div class="title">${unsafeHTML(this.title)}</div>
         <div class="text">${unsafeHTML(this.text)}</div>


### PR DESCRIPTION
## What I did

1. Generalized rocket search label, so it works for all extending parties
2. Added alt attribute to images search results for a11y
