### PR TITLE
feat(navigation): add no-redirects attribute

### DIFF
--- a/.changeset/nasty-hats-smash.md
+++ b/.changeset/nasty-hats-smash.md
@@ -1,0 +1,13 @@
+---
+"@rocket/navigation": patch
+---
+
+feat(navigation): add no-redirects attribute
+
+By default, the sidebar nav redirects clicks on category headings to
+their first child.
+
+To disable those redirects, override
+_includes/_joiningBlocks/_layoutSidebar/sidebar/20-navigation.njk
+and add the no-redirects attribute to the <rocket-navigation>
+element.

--- a/docs/guides/first-pages/manage-sidebar.md
+++ b/docs/guides/first-pages/manage-sidebar.md
@@ -47,3 +47,9 @@ export const headlineConverter = () => html`
 ```
 
 How it then works is very similar to https://www.11ty.dev/docs/plugins/navigation/
+
+## Sidebar redirects
+
+By default, the sidebar nav redirects clicks on category headings to the first child page in that category.
+
+To disable those redirects, override `_includes/_joiningBlocks/_layoutSidebar/sidebar/20-navigation.njk` and add the `no-redirects` attribute to the `<rocket-navigation>` element.

--- a/packages/navigation/src/RocketNavigation.js
+++ b/packages/navigation/src/RocketNavigation.js
@@ -1,16 +1,45 @@
 /**
+ * Debounce a function
+ * @template {(this: any, ...args: any[]) => void} T
+ * @param  {T}       func      function
+ * @param  {number}  wait      time in milliseconds to debounce
+ * @param  {boolean} immediate when true, run immediately and on the leading edge
+ * @return {T}                 debounced function
+ */
+function debounce(func, wait, immediate) {
+  /** @type {number|undefined} */
+  let timeout;
+  return /** @type {typeof func}*/ (function () {
+    let args = /** @type {Parameters<typeof func>} */ (/** @type {unknown}*/ (arguments));
+    const later = () => {
+      timeout = undefined;
+      if (!immediate) func.apply(this, args);
+    };
+    const callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(this, args);
+  });
+}
+
+/**
  * @typedef {object} NavigationListItem
  * @property {HTMLElement} headline
  * @property {HTMLAnchorElement} anchor
  * @property {number} top
  */
 
+/**
+ * @element rocket-navigation
+ * @attr {Boolean} no-redirects - if set, will not redirect to first child of nav category when clicking on category header.
+ */
 export class RocketNavigation extends HTMLElement {
   constructor() {
     super();
     /** @type NavigationListItem[] */
     this.list = [];
-    this.__scrollHandler = this.__scrollHandler.bind(this);
+    this.__clickHandler = this.__clickHandler.bind(this);
+    this.__scrollHandler = debounce(this.__scrollHandler.bind(this), 25, true);
     this.__isSetup = false;
   }
 
@@ -20,27 +49,7 @@ export class RocketNavigation extends HTMLElement {
     }
     this.__isSetup = true;
 
-    this.addEventListener('click', ev => {
-      const el = /** @type {HTMLElement} */ (ev.target);
-      if (el.classList.contains('anchor')) {
-        const anchor = /** @type {HTMLAnchorElement} */ (el);
-        ev.preventDefault();
-        this.dispatchEvent(new Event('close-overlay', { bubbles: true }));
-        // wait for closing animation to finish before start scrolling
-        setTimeout(() => {
-          const parsedUrl = new URL(anchor.href);
-          document.location.hash = parsedUrl.hash;
-        }, 250);
-      }
-      const links = el.parentElement?.querySelectorAll('ul a');
-      if (links && links.length > 1) {
-        const subLink = /** @type {HTMLAnchorElement} */ (links[1]);
-        if (!subLink.classList.contains('anchor')) {
-          ev.preventDefault();
-          subLink.click();
-        }
-      }
-    });
+    this.addEventListener('click', this.__clickHandler);
 
     const anchors = /** @type {NodeListOf<HTMLAnchorElement>} */ (this.querySelectorAll(
       'li.current a.anchor',
@@ -57,10 +66,39 @@ export class RocketNavigation extends HTMLElement {
       }
     }
 
-    // TODO: debounce
-    window.addEventListener('scroll', this.__scrollHandler);
+    window.addEventListener('scroll', this.__scrollHandler, { passive: true });
 
     this.__scrollHandler();
+  }
+
+  /**
+   * @param  {Event} ev
+   */
+  __clickHandler(ev) {
+    const el = /** @type {HTMLElement} */ (ev.target);
+    if (el.classList.contains('anchor')) {
+      const anchor =
+        el instanceof HTMLAnchorElement
+          ? el
+          : /** @type{HTMLAnchorElement} */ (el.querySelector('a.anchor'));
+      ev.preventDefault();
+      this.dispatchEvent(new Event('close-overlay', { bubbles: true }));
+      // wait for closing animation to finish before start scrolling
+      setTimeout(() => {
+        const parsedUrl = new URL(anchor.href);
+        document.location.hash = parsedUrl.hash;
+      }, 250);
+    }
+    if (!this.hasAttribute('no-redirects')) {
+      const links = el.parentElement?.querySelectorAll('ul a');
+      if (links && links.length > 1) {
+        const subLink = /** @type {HTMLAnchorElement} */ (links[1]);
+        if (!subLink.classList.contains('anchor')) {
+          ev.preventDefault();
+          subLink.click();
+        }
+      }
+    }
   }
 
   __scrollHandler() {

--- a/packages/navigation/test-web/rocket-navigation.test.js
+++ b/packages/navigation/test-web/rocket-navigation.test.js
@@ -58,7 +58,8 @@ describe('rocket-navigation', () => {
     expect(anchorSpy).to.not.be.called;
   });
 
-  it('will mark the currently "active" headline in the menu', async () => {
+  it('will mark the currently "active" headline in the menu', async function () {
+    this.timeout(5000);
     function addBlock(headline, length = 5) {
       return html`
         <h2 id="${headline}">${headline}</h2>
@@ -96,20 +97,20 @@ describe('rocket-navigation', () => {
         }
       </style>
     `);
-    await aTimeout(0);
+    await aTimeout(50);
     const anchorLis = wrapper.querySelectorAll('.menu-item.anchor');
     expect(anchorLis[0]).to.have.class('current');
     expect(anchorLis[1]).to.not.have.class('current');
     expect(anchorLis[2]).to.not.have.class('current');
 
     document.querySelector('#middle').scrollIntoView();
-    await aTimeout(20);
+    await aTimeout(100);
     expect(anchorLis[0]).to.not.have.class('current');
     expect(anchorLis[1]).to.have.class('current');
     expect(anchorLis[2]).to.not.have.class('current');
 
     document.querySelector('#bottom').scrollIntoView();
-    await aTimeout(20);
+    await aTimeout(100);
     expect(anchorLis[0]).to.not.have.class('current');
     expect(anchorLis[1]).to.not.have.class('current');
     expect(anchorLis[2]).to.have.class('current');


### PR DESCRIPTION
By default, the sidebar nav redirects clicks on category headings to
their first child.

To disable those redirects, override
`_includes/_joiningBlocks/_layoutSidebar/sidebar/20-navigation.njk`
and add the `no-redirects` attribute to the `<rocket-navigation>`
element.

## What I did

1. check for `no-redirects` attribute before preventing default click handler and redirecting
2. debounce scroll spy
3. fix a test which was failing when it expected an anchor and got a list item
4. adjust tests to handle debounced scroll listener
