### PR TITLE
feat: upgrade to lit major prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "hanbi": "^0.4.1",
     "husky": "^4.3.7",
     "lint-staged": "^10.5.3",
+    "lit-element": "^3.0.0-pre.4",
+    "lit-html": "^2.0.0-pre.7",
     "mocha": "^8.2.1",
     "node-fetch": "^2.6.1",
     "npm-run-all": "^4.1.5",

--- a/packages/building-rollup/demo/ts/demo-app.ts
+++ b/packages/building-rollup/demo/ts/demo-app.ts
@@ -1,4 +1,5 @@
-import { LitElement, html, customElement } from 'lit-element';
+import { LitElement, html } from 'lit-element';
+import { customElement } from 'lit-element/decorators.js';
 
 const msg: string = 'TypeScript demo works';
 

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@lion/overlays": "^0.23.2",
-    "lit-element": "^2.4.0"
+    "lit-element": "^3.0.0-pre.4"
   },
   "types": "dist-types/index.d.ts"
 }

--- a/packages/mdjs-preview/package.json
+++ b/packages/mdjs-preview/package.json
@@ -32,8 +32,8 @@
     "src"
   ],
   "dependencies": {
-    "lit-element": "^2.4.0",
-    "lit-html": "^1.3.0"
+    "lit-element": "^3.0.0-pre.4",
+    "lit-html": "^2.0.0-pre.7"
   },
   "types": "dist-types/index.d.ts"
 }

--- a/packages/mdjs-story/package.json
+++ b/packages/mdjs-story/package.json
@@ -32,7 +32,7 @@
     "src"
   ],
   "dependencies": {
-    "lit-element": "^2.4.0"
+    "lit-element": "^3.0.0-pre.4"
   },
   "types": "dist-types/index.d.ts"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,14 +1135,14 @@
     "@hapi/hoek" "^8.3.0"
 
 "@lion/combobox@^0.1.20":
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/@lion/combobox/-/combobox-0.1.20.tgz#9514c655171773a12f9c841187297f8791a029a6"
-  integrity sha512-Iw3BzZv7K36c2ReBDD76298VrNTPe7XElGAnr9/jzTH22eJdZD33DBXcY3D/tJlrhh02aC+4nTYxTww33lRqCA==
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/@lion/combobox/-/combobox-0.1.24.tgz#c50ea6c4f7fe7e9f7c32519cac38d67311c45ab9"
+  integrity sha512-zI10/lxLUJLgIMEDsddFuG5q4T37gJDBwtFbcsteNtCIH/OiSbys8Ac+ld9NXqu7Ahi2iy8wJUX/JLIbqAq2nQ==
   dependencies:
-    "@lion/core" "0.13.7"
-    "@lion/form-core" "0.7.0"
-    "@lion/listbox" "0.4.0"
-    "@lion/overlays" "0.23.2"
+    "@lion/core" "0.13.8"
+    "@lion/form-core" "0.7.3"
+    "@lion/listbox" "0.4.3"
+    "@lion/overlays" "0.23.4"
 
 "@lion/core@0.13.7":
   version "0.13.7"
@@ -1154,32 +1154,51 @@
     lit-element "~2.4.0"
     lit-html "^1.3.0"
 
-"@lion/form-core@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@lion/form-core/-/form-core-0.7.0.tgz#0df2cefb62876dd62e2baa980129ed7bf790b3ae"
-  integrity sha512-5aWqKNQgJKgqJC6VIRNoGe5imz9w0thLEnPqWJ8y6vSru/BC114ZLefvmltK9FG21DPkPOCa+vm4PSjilaqh1w==
+"@lion/core@0.13.8":
+  version "0.13.8"
+  resolved "https://registry.yarnpkg.com/@lion/core/-/core-0.13.8.tgz#3ee9b32b0f3cbbeec5a9050de88e36651c80ce5b"
+  integrity sha512-GIADzAQGnxGTzOf3N1FWjtSa7hWlt+I/KPJdbqQg8SHjtQLpzmXAbP1orkqdt+bkUQXotLaNbi1DUWYdu2Emtg==
   dependencies:
-    "@lion/core" "0.13.7"
-    "@lion/localize" "0.15.4"
+    "@open-wc/dedupe-mixin" "^1.2.18"
+    "@open-wc/scoped-elements" "^1.3.3"
+    lit-element "~2.4.0"
+    lit-html "^1.3.0"
 
-"@lion/listbox@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@lion/listbox/-/listbox-0.4.0.tgz#429838fd75d40662b67e5a3f611bf3ea94b506de"
-  integrity sha512-bwVIlVX0cQoKKGf6HNqDmTH5JUM0TKAzZuHsrmLcsYG9V5bgMjfiLBXPNQxyy39WOwicPM8f2g+O5rRXBcsIYQ==
+"@lion/form-core@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@lion/form-core/-/form-core-0.7.3.tgz#31b65e23c2bf44a97cade530efaf395d87b6fad9"
+  integrity sha512-K1PPR20nynWq+DTAUV7PVwrNc109srldIJAsdeysQLGLnsEntl4PQmZBrc0fB3+ZHFyg0EaPgpD+tnRqgt/zbg==
   dependencies:
-    "@lion/core" "0.13.7"
-    "@lion/form-core" "0.7.0"
+    "@lion/core" "0.13.8"
+    "@lion/localize" "0.15.5"
 
-"@lion/localize@0.15.4":
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/@lion/localize/-/localize-0.15.4.tgz#b9ed5eb5b3a1304694314b4d6bbbcddc0b85f616"
-  integrity sha512-OP7Og/JXWl4Wm+AzLNKcCAoeft5eQfZlkvEFqOnRuGAXxotbxwk+yQB3kI/K7QvLURNQbv6mzwdDu2buhZdV9w==
+"@lion/listbox@0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@lion/listbox/-/listbox-0.4.3.tgz#42ff912660b1988e4ac2790a299140e14ab3e90d"
+  integrity sha512-igvRz3yjb2vcBvM1mkM4im8ZE+jAaPTCiO9v/Y+U4HdUGBLhqmJqTazilybpwQ5xjaF3Q2/sN4RrpI+EmVDzwg==
+  dependencies:
+    "@lion/core" "0.13.8"
+    "@lion/form-core" "0.7.3"
+
+"@lion/localize@0.15.5":
+  version "0.15.5"
+  resolved "https://registry.yarnpkg.com/@lion/localize/-/localize-0.15.5.tgz#08dca16717a4b6659340364488a6fe65e05467ed"
+  integrity sha512-tArABFvqM6zyrvO1dN/6l6QyEI7414lriLS/M3RmjyvNV+E/zDAEOAj82RXbtevJAuTLVpM5K2kx2yF3KdoMmg==
   dependencies:
     "@bundled-es-modules/message-format" "6.0.4"
-    "@lion/core" "0.13.7"
+    "@lion/core" "0.13.8"
     singleton-manager "1.2.1"
 
-"@lion/overlays@0.23.2", "@lion/overlays@^0.23.2":
+"@lion/overlays@0.23.4":
+  version "0.23.4"
+  resolved "https://registry.yarnpkg.com/@lion/overlays/-/overlays-0.23.4.tgz#7a4fa4e228b32ffaa9259055dab43a4b3d88a32b"
+  integrity sha512-yXlDwh3nU2hn+9dkud4XTbAFYnpU2op8fwNqxwKH0S0sEEWsHlngQZrgwPKMkpZqW+2qxA0anV/GGChjwupQSg==
+  dependencies:
+    "@lion/core" "0.13.8"
+    "@popperjs/core" "^2.5.4"
+    singleton-manager "1.2.1"
+
+"@lion/overlays@^0.23.2":
   version "0.23.2"
   resolved "https://registry.yarnpkg.com/@lion/overlays/-/overlays-0.23.2.tgz#cfdff6cb7ee4f46cdaa621574affbe2e9c374976"
   integrity sha512-nKVSn37arx9+gdmlIj3gEkpJXGTnsUvbOEXcymLEFJBekvdYKCNWDe9bVBX/iTBBsgO0rQ9+eA5RskxwKPdraQ==
@@ -1187,6 +1206,11 @@
     "@lion/core" "0.13.7"
     "@popperjs/core" "^2.5.4"
     singleton-manager "1.2.1"
+
+"@lit/reactive-element@^1.0.0-pre.3":
+  version "1.0.0-pre.3"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0-pre.3.tgz#c70728ff8ea7b2c723493386ad12d709e33adbd6"
+  integrity sha512-hwVozBTO2FfgeTUH9cg5US+Qzf9b1EqKHMIVzMNyQdReCZ51NGbNBbp8O+y2sqBcQ03RPLa7rthBc/58XUFTpA==
 
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
@@ -1247,6 +1271,14 @@
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-1.3.2.tgz#6ae54c49731bbe8c3e0b5383c989f983dcdfacf5"
   integrity sha512-DoP3XA8r03tGx+IrlJwP/voLuDFkyS56kvwhmXIhpESo7M5jMt5e0zScNrawj7EMe4b5gDaJjorx2Jza8FLaLw==
+  dependencies:
+    "@open-wc/dedupe-mixin" "^1.3.0"
+    lit-html "^1.0.0"
+
+"@open-wc/scoped-elements@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-1.3.3.tgz#fe008aef4d74fb00c553c900602960638fc1c7b0"
+  integrity sha512-vFIQVYYjFw67odUE4JzZOpctnF7S/2DX+S+clrL3bQPql7HvEnV0wMFwOWUavQTuCJi0rfU8GTcNMiUybio+Yg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
     lit-html "^1.0.0"
@@ -5388,17 +5420,39 @@ listr2@^3.2.2:
     rxjs "^6.6.3"
     through "^2.3.8"
 
-lit-element@^2.0.1, lit-element@^2.2.1, lit-element@^2.4.0, lit-element@~2.4.0:
+lit-element@^2.0.1, lit-element@^2.2.1, lit-element@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.4.0.tgz#b22607a037a8fc08f5a80736dddf7f3f5d401452"
   integrity sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==
   dependencies:
     lit-html "^1.1.1"
 
+lit-element@^3.0.0-pre.4:
+  version "3.0.0-pre.4"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.0.0-pre.4.tgz#564930d196193666232636d6bc06efd7965ceac5"
+  integrity sha512-5fNufIe3aad1q66DBoBAn+LtbynEE4RXaZDUO0RIGsDoz3ytizR7pMo/zvZGl21QOC0gxlWEm55QzMXdE9EUDg==
+  dependencies:
+    "@lit/reactive-element" "^1.0.0-pre.3"
+    lit-html "^2.0.0-pre.7"
+
 lit-html@^1.0.0, lit-html@^1.1.1, lit-html@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
   integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
+
+lit-html@^2.0.0-pre.7:
+  version "2.0.0-pre.7"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.0-pre.7.tgz#499fa78a0119bb4f4398944f6bebf1b265ced914"
+  integrity sha512-qy/fHSRzf7cCbXGLXVBRwecnLgioyvkKbk4WGVswbelK6OD5tqhwY2wVWclEA0JEuNkGQW81ad15BeGxR46uig==
+
+lit@^2.0.0-pre.2:
+  version "2.0.0-pre.2"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.0-pre.2.tgz#b7679c5c253aab6b7e6929b88d45049c14dbd7ed"
+  integrity sha512-IEnHFvhmk2ir+S010tPZoqmPKcXB8+srOJOSnRT8G6fnU//fAFhmUwMHEHwFyOcftjODsXWK8dSv6+j4ms4c/Q==
+  dependencies:
+    "@lit/reactive-element" "^1.0.0-pre.3"
+    lit-element "^3.0.0-pre.4"
+    lit-html "^2.0.0-pre.7"
 
 load-json-file@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What I did

1. I updated the dependencies to the next major version of lit-element and lit-html.
2. Added lit-element and lit-html to main package.json to override the versions of lion.

If you want I can also change all your dependencies to `lit`, so point 2 isn't needed, but they advice to wait with this step.

> Although the lit-element@^3 and lit-html@^2 packages should be largely backward-compatible, we recommend updating to the lit package as the other packages are moving towards eventual deprecation. (from [Lit-2.0-Upgrade-Guide](https://github.com/Polymer/lit-html/wiki/Lit-2.0-Upgrade-Guide))

Since its based on prereleases, feel free to change the target branch.