### PR TITLE
fix: windows path issue avoid filtering of index section of collections

### DIFF
--- a/.changeset/thirty-turkeys-own.md
+++ b/.changeset/thirty-turkeys-own.md
@@ -1,0 +1,5 @@
+---
+'@rocket/cli': patch
+---
+
+fix: windows path issue avoid filtering of index section of collections

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,6 +73,7 @@
     "fs-extra": "^9.0.1",
     "micromatch": "^4.0.2",
     "plugins-manager": "^0.2.1",
+    "slash": "^3.0.0",
     "utf8": "^3.0.0"
   },
   "types": "dist-types/index.d.ts"

--- a/packages/cli/src/eleventy-plugins/rocketCollections.cjs
+++ b/packages/cli/src/eleventy-plugins/rocketCollections.cjs
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const slash = require('slash');
 const { readdirSync } = require('fs');
 
 function getDirectories(source) {
@@ -23,7 +24,7 @@ const rocketCollections = {
           let docs = [
             ...collection.getFilteredByGlob(`${_inputDirCwdRelative}/${section}/**/*.md`),
           ];
-          docs = docs.filter(page => page.inputPath !== `./${indexSection}`);
+          docs = docs.filter(page => page.inputPath !== `./${slash(indexSection)}`);
 
           return docs;
         });


### PR DESCRIPTION
## What I did

1. Fix an issue on windows because of the path with backslashes.

On windows, the /blog uses the blog detail layout and display a wrong navigation sidebar:

![image](https://user-images.githubusercontent.com/9367152/114258859-95f67300-9997-11eb-8ee2-8ebfd92ece5d.png)

