### PR TITLE
fix: windows path issue when using rocket lint

### DIFF
--- a/.changeset/silent-hairs-cheat.md
+++ b/.changeset/silent-hairs-cheat.md
@@ -1,0 +1,5 @@
+---
+'check-html-links': patch
+---
+
+fix: windows path issue

--- a/packages/check-html-links/src/validateFolder.js
+++ b/packages/check-html-links/src/validateFolder.js
@@ -6,6 +6,7 @@ import { createRequire } from 'module';
 
 import { listFiles } from './listFiles.js';
 import path from 'path';
+import slash from 'slash';
 
 /** @typedef {import('../types/main').Link} Link */
 /** @typedef {import('../types/main').LocalFile} LocalFile */
@@ -45,7 +46,7 @@ function extractReferences(htmlFilePath) {
     if (ev === SaxEventType.Attribute) {
       const data = /** @type {Attribute} */ (/** @type {any} */ (_data));
       const attributeName = data.name.toString();
-      const value = data.value.toString();
+      const value = slash(data.value.toString());
       const entry = {
         attribute: attributeName,
         value,


### PR DESCRIPTION
## What I did

1. fix `rocket lint` with windows path

I didn't check the lint feature when I fixed it for the `rocket start` in https://github.com/modernweb-dev/rocket/pull/104
