### PR TITLE
fix: warning UnhandledPromiseRejectionWarning not throwing with node < 15

### DIFF
--- a/.changeset/stale-oranges-report.md
+++ b/.changeset/stale-oranges-report.md
@@ -1,0 +1,5 @@
+---
+'@rocket/cli': patch
+---
+
+fix: warning UnhandledPromiseRejectionWarning not throwing with node < 15

--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -4,3 +4,7 @@ import { RocketCli } from './RocketCli.js';
 
 const cli = new RocketCli();
 cli.run();
+
+process.on('unhandledRejection', up => {
+  throw up;
+});


### PR DESCRIPTION
When you use rocket lint with a version prior to node 15, when you have links errors it does not throw an error but emit a warning:

```
(Use `node --trace-warnings ...` to show where the warning was created)
(node:49856) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:49856) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

The exit code of the command is `0` and is not considered as an error.

Node has changed this behavior from the version 15.0.0:
> v15.0.0  Changed default mode to throw. Previously, a warning was emitted.

See https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode

I didn't changed the behavior your have on node 15 but it could be good to catch these errors and do a process exit instead.