### PR TITLE
fix(mdjs-core): support importing via es module

### DIFF
--- a/.changeset/good-ears-move.md
+++ b/.changeset/good-ears-move.md
@@ -1,0 +1,9 @@
+---
+'@mdjs/core': patch
+---
+
+Support importing via es module
+
+```js
+import { mdjsProcess } = from '@mdjs/core';
+```

--- a/packages/mdjs-core/package.json
+++ b/packages/mdjs-core/package.json
@@ -32,6 +32,7 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "*.mjs",
     "dist-types",
     "src",
     "types"


### PR DESCRIPTION
## What I did

1. fix(mdjs-core): support importing via es module
