### PR TITLE
fix(plugins-manager): fix types for optional parameters

### DIFF
--- a/.changeset/fresh-files-deny.md
+++ b/.changeset/fresh-files-deny.md
@@ -1,0 +1,5 @@
+---
+'plugins-manager': patch
+---
+
+Optional parameters are now also define as optional in types

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "sinon": "^9.2.3",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.2"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",

--- a/packages/eleventy-plugin-mdjs-unified/package.json
+++ b/packages/eleventy-plugin-mdjs-unified/package.json
@@ -31,7 +31,7 @@
     "mdjs"
   ],
   "dependencies": {
-    "@mdjs/core": "^0.7.1",
+    "@mdjs/core": "^0.7.2",
     "es-module-lexer": "^0.3.26",
     "unist-util-visit": "^2.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8347,10 +8347,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
+  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What I did

1. Bumping tsc version so it respects jsdoc optional parameters when generating typings
