### PR TITLE
feat: update mdjs to lit & render to light dom

### DIFF
--- a/.changeset/core-light-dom.md
+++ b/.changeset/core-light-dom.md
@@ -1,0 +1,22 @@
+---
+'@mdjs/core': minor
+---
+
+**BREAKING CHANGE** Stories of `story` and `preview-story` are now rendered to light dom instead of shadow dom to allow usage of a scoped registry for the internal dom
+
+```js
+export const story = html`<p>my story</p>`;
+```
+
+```html
+<!-- before -->
+<mdjs-story>
+  #shadow-root (open)
+    <p>my story</p>
+</mdjs-story>
+
+<!-- after -->
+<mdjs-story>
+  <p>my story</p>
+</mdjs-story>
+```

--- a/.changeset/core.md
+++ b/.changeset/core.md
@@ -1,0 +1,17 @@
+---
+'@mdjs/core': minor
+---
+
+**BREAKING CHANGE** The default renderer for `story` and `preview-story` updated to [lit](https://lit.dev/) 2
+
+If your main lit-html version is 1.x be sure to import html for your story rendering from `@mdjs/mdjs-preview`.
+
+````md
+```js script
+import { html } from '@mdjs/mdjs-preview';
+```
+
+```js preview-story
+export const foo = () => html`<demo-element></demo-element>`;
+```
+````

--- a/.changeset/dirty-vans-brush.md
+++ b/.changeset/dirty-vans-brush.md
@@ -1,0 +1,17 @@
+---
+'@mdjs/mdjs-preview': minor
+---
+
+**BREAKING CHANGE** Update to [lit](https://lit.dev/) 2
+
+If your main lit-html version is 1.x be sure to import html for your story rendering from `@mdjs/mdjs-preview`.
+
+````md
+```js script
+import { html } from '@mdjs/mdjs-preview';
+```
+
+```js preview-story
+export const foo = () => html`<demo-element></demo-element>`;
+```
+````

--- a/.changeset/light-dom-story.md
+++ b/.changeset/light-dom-story.md
@@ -1,0 +1,22 @@
+---
+'@mdjs/mdjs-story': minor
+---
+
+**BREAKING CHANGE** Render stories to light dom
+
+```js
+export const story = html`<p>my story</p>`;
+```
+
+```html
+<!-- before -->
+<mdjs-story>
+  #shadow-root (open)
+    <p>my story</p>
+</mdjs-story>
+
+<!-- after -->
+<mdjs-story>
+  <p>my story</p>
+</mdjs-story>
+```

--- a/.changeset/mighty-grapes-build.md
+++ b/.changeset/mighty-grapes-build.md
@@ -1,0 +1,36 @@
+---
+'@mdjs/mdjs-preview': minor
+---
+
+**BREAKING CHANGE** Render stories to light dom
+
+```js
+export const story = html`<p>my story</p>`;
+```
+
+```html
+<!-- before -->
+<mdjs-preview>
+  #shadow-root (open)
+    <div id="wrapper">
+      <div>
+        <p>my story</p>
+      </div>
+    </div>
+    <!-- more internal dom -->
+
+  <code><!-- ... --></code>
+</mdjs-preview>
+
+<!-- after -->
+<mdjs-preview>
+  #shadow-root (open)
+    <div id="wrapper">
+    <!-- more internal dom -->
+
+  <code><!-- ... --></code>
+  <div slot="story">
+    <p>my story</p>
+  </div>
+</mdjs-preview>
+```

--- a/.changeset/story.md
+++ b/.changeset/story.md
@@ -1,0 +1,17 @@
+---
+'@mdjs/mdjs-story': minor
+---
+
+**BREAKING CHANGE** Update to [lit](https://lit.dev/) 2
+
+If your main lit-html version is 1.x be sure to import html for your story rendering from `@mdjs/mdjs-story`.
+
+````md
+```js script
+import { html } from '@mdjs/mdjs-story';
+```
+
+```js story
+export const foo = () => html`<demo-element></demo-element>`;
+```
+````

--- a/docs/docs/markdown-javascript/overview.md
+++ b/docs/docs/markdown-javascript/overview.md
@@ -1,5 +1,11 @@
 # Markdown JavaScript >> Overview || 10
 
+```js script
+import '@mdjs/mdjs-story/define';
+import '@mdjs/mdjs-preview/define';
+import { html } from '@mdjs/mdjs-story';
+```
+
 Markdown JavaScript (mdjs) is a format that allows you to use JavaScript with Markdown, to create interactive demos. It does so by "annotating" JavaScript that should be executed in Markdown.
 
 To annotate we use a code block with `js script`.
@@ -63,13 +69,6 @@ import '@mdjs/mdjs-preview/define';
 
 Once loaded you can use them like so:
 
-````md
-```js script
-import '@mdjs/mdjs-story/define';
-import '@mdjs/mdjs-preview/define';
-```
-````
-
 ### Story
 
 The code snippet will actually get executed at that place and you will have a live demo
@@ -116,12 +115,6 @@ export const JsPreviewStory = () => html` <demo-wc-card>JS Preview Story</demo-w
 ````
 
 Here is a live example from [demo-wc-card](https://www.npmjs.com/package/demo-wc-card).
-
-```js script
-import '@mdjs/mdjs-story/define';
-import '@mdjs/mdjs-preview/define';
-import { html } from 'lit-html';
-```
 
 ```js preview-story
 import 'demo-wc-card/demo-wc-card.js';

--- a/docs/docs/markdown-javascript/preview.md
+++ b/docs/docs/markdown-javascript/preview.md
@@ -17,7 +17,7 @@ You can showcase live running code by annotating a code block with `js preview-s
 - Settings can be remembered for other pages / return visits
 
 ```js script
-import { html } from 'lit-html';
+import { html } from '@mdjs/mdjs-preview';
 import './assets/demo-element.js';
 ```
 
@@ -25,7 +25,7 @@ import './assets/demo-element.js';
 
 ````md
 ```js script
-import { html } from 'lit-html';
+import { html } from '@mdjs/mdjs-preview';
 import './assets/demo-element.js';
 ```
 

--- a/docs/docs/markdown-javascript/story.md
+++ b/docs/docs/markdown-javascript/story.md
@@ -3,12 +3,12 @@
 You can showcase live running code by annotating a code block with `js story`.
 
 ```js script
-import { html } from 'lit-html';
+import { html } from '@mdjs/mdjs-story';
 ```
 
 ````md
 ```js script
-import { html } from 'lit-html';
+import { html } from '@mdjs/mdjs-story';
 ```
 
 ```js story

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.12.0",
-    "@open-wc/testing": "^2.5.32",
+    "@open-wc/testing": "^3.0.0-next.1",
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-typescript": "^8.1.0",

--- a/packages/cli/preset/_includes/layout-simulator.njk
+++ b/packages/cli/preset/_includes/layout-simulator.njk
@@ -11,7 +11,7 @@
       }
     </style>
     <script type="module">
-      import { render } from 'lit-html';
+      import { render } from '@mdjs/mdjs-story';
 
       async function onHashChange() {
         const urlParts = new URLSearchParams(document.location.hash.substr(1));

--- a/packages/mdjs-preview/index.js
+++ b/packages/mdjs-preview/index.js
@@ -1,1 +1,62 @@
 export { MdJsPreview } from './src/MdJsPreview.js';
+
+// reexport used lit to ensure users can sync html & rendering
+export {
+  html,
+  CSSResult,
+  adoptStyles,
+  css,
+  getCompatibleStyle,
+  supportsAdoptingStyleSheets,
+  unsafeCSS,
+  UpdatingElement,
+  notEqual,
+  ReactiveElement,
+  svg,
+  noChange,
+  nothing,
+  render,
+  LitElement,
+  defaultConverter,
+} from 'lit';
+
+export {
+  customElement,
+  property,
+  state,
+  eventOptions,
+  query,
+  queryAll,
+  queryAsync,
+  queryAssignedNodes,
+} from 'lit/decorators.js';
+
+export { directive, Directive } from 'lit/directive.js';
+
+export { AsyncDirective } from 'lit/async-directive.js';
+
+export {
+  isPrimitive,
+  TemplateResultType,
+  isTemplateResult,
+  isDirectiveResult,
+  getDirectiveClass,
+  isSingleExpression,
+  insertPart,
+  setChildPartValue,
+  setCommittedValue,
+  getCommittedValue,
+  removePart,
+  clearPart,
+} from 'lit/directive-helpers.js';
+
+export { asyncAppend } from 'lit/directives/async-append.js';
+export { asyncReplace } from 'lit/directives/async-replace.js';
+export { cache } from 'lit/directives/cache.js';
+export { classMap } from 'lit/directives/class-map.js';
+export { guard } from 'lit/directives/guard.js';
+export { ifDefined } from 'lit/directives/if-defined.js';
+export { repeat } from 'lit/directives/repeat.js';
+export { styleMap } from 'lit/directives/style-map.js';
+export { unsafeHTML } from 'lit/directives/unsafe-html.js';
+export { until } from 'lit/directives/until.js';

--- a/packages/mdjs-preview/package.json
+++ b/packages/mdjs-preview/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "@lion/accordion": "^0.4.2",
-    "lit-element": "^2.4.0"
+    "lit": "^2.0.0-rc.2"
   },
   "types": "dist-types/index.d.ts"
 }

--- a/packages/mdjs-preview/package.json
+++ b/packages/mdjs-preview/package.json
@@ -22,7 +22,6 @@
   "scripts": {
     "debug": "cd ../../ && npm run debug -- --group mdjs-preview",
     "test": "npm run test:web",
-    "test:watch": "onchange 'src/**/*.{js,cjs}' 'test-node/**/*.js' -- npm run test:node",
     "test:web": "cd ../../ && npm run test:web -- --group mdjs-preview"
   },
   "files": [

--- a/packages/mdjs-preview/src/MdJsPreview.js
+++ b/packages/mdjs-preview/src/MdJsPreview.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit-element';
+import { LitElement, html, css } from 'lit';
 import '@lion/accordion/define';
 
 import {

--- a/packages/mdjs-preview/test-web/mdjs-preview.test.js
+++ b/packages/mdjs-preview/test-web/mdjs-preview.test.js
@@ -1,4 +1,5 @@
 import { expect, fixture, html } from '@open-wc/testing';
+import { html as storyHtml } from '@mdjs/mdjs-preview';
 import '@mdjs/mdjs-preview/define';
 
 /** @typedef {import('@mdjs/mdjs-preview').MdJsPreview} MdJsPreview */
@@ -6,16 +7,16 @@ import '@mdjs/mdjs-preview/define';
 describe('mdjs-preview', () => {
   it('will render the element into the shadow root by default', async () => {
     const el = await fixture(html`
-      <mdjs-preview .story=${() => html`<p id="testing"></p>`}></mdjs-preview>
+      <mdjs-preview .story=${() => storyHtml`<p id="testing"></p>`}></mdjs-preview>
     `);
-    expect(el.shadowRoot.querySelectorAll('#testing').length).to.equal(1);
+    expect(el.querySelectorAll('#testing').length).to.equal(1);
   });
 
   it('sync simulator states between instances', async () => {
     const el = await fixture(html`
       <div>
-        <mdjs-preview .story=${() => html`<p></p>`}></mdjs-preview>
-        <mdjs-preview .story=${() => html`<p></p>`}></mdjs-preview>
+        <mdjs-preview .story=${() => storyHtml`<p></p>`}></mdjs-preview>
+        <mdjs-preview .story=${() => storyHtml`<p></p>`}></mdjs-preview>
       </div>
     `);
     const [preview1, preview2] = /** @type {MdJsPreview[]} */ (el.children);

--- a/packages/mdjs-story/index.js
+++ b/packages/mdjs-story/index.js
@@ -1,1 +1,62 @@
 export { MdJsStory } from './src/MdJsStory.js';
+
+// reexport used lit to ensure users can sync html & rendering
+export {
+  html,
+  CSSResult,
+  adoptStyles,
+  css,
+  getCompatibleStyle,
+  supportsAdoptingStyleSheets,
+  unsafeCSS,
+  UpdatingElement,
+  notEqual,
+  ReactiveElement,
+  svg,
+  noChange,
+  nothing,
+  render,
+  LitElement,
+  defaultConverter,
+} from 'lit';
+
+export {
+  customElement,
+  property,
+  state,
+  eventOptions,
+  query,
+  queryAll,
+  queryAsync,
+  queryAssignedNodes,
+} from 'lit/decorators.js';
+
+export { directive, Directive } from 'lit/directive.js';
+
+export { AsyncDirective } from 'lit/async-directive.js';
+
+export {
+  isPrimitive,
+  TemplateResultType,
+  isTemplateResult,
+  isDirectiveResult,
+  getDirectiveClass,
+  isSingleExpression,
+  insertPart,
+  setChildPartValue,
+  setCommittedValue,
+  getCommittedValue,
+  removePart,
+  clearPart,
+} from 'lit/directive-helpers.js';
+
+export { asyncAppend } from 'lit/directives/async-append.js';
+export { asyncReplace } from 'lit/directives/async-replace.js';
+export { cache } from 'lit/directives/cache.js';
+export { classMap } from 'lit/directives/class-map.js';
+export { guard } from 'lit/directives/guard.js';
+export { ifDefined } from 'lit/directives/if-defined.js';
+export { repeat } from 'lit/directives/repeat.js';
+export { styleMap } from 'lit/directives/style-map.js';
+export { unsafeHTML } from 'lit/directives/unsafe-html.js';
+export { until } from 'lit/directives/until.js';

--- a/packages/mdjs-story/package.json
+++ b/packages/mdjs-story/package.json
@@ -22,7 +22,6 @@
   "scripts": {
     "debug": "cd ../../ && npm run debug -- --group mdjs-story",
     "test": "npm run test:web",
-    "test:watch": "onchange 'src/**/*.{js,cjs}' 'test-node/**/*.js' -- npm run test:node",
     "test:web": "cd ../../ && npm run test:web -- --group mdjs-story"
   },
   "files": [

--- a/packages/mdjs-story/package.json
+++ b/packages/mdjs-story/package.json
@@ -32,7 +32,7 @@
     "src"
   ],
   "dependencies": {
-    "lit-element": "^2.4.0"
+    "lit": "^2.0.0-rc.2"
   },
   "types": "dist-types/index.d.ts"
 }

--- a/packages/mdjs-story/src/MdJsStory.js
+++ b/packages/mdjs-story/src/MdJsStory.js
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit';
 
 /**
  * @typedef {object} StoryOptions
- * @property {ShadowRoot | null} StoryOptions.shadowRoot
+ * @property {HTMLElement | null} StoryOptions.shadowRoot
  */
 
 /** @typedef {(options?: StoryOptions) => ReturnType<LitElement['render']>} LitHtmlStoryFn */
@@ -28,7 +28,11 @@ export class MdJsStory extends LitElement {
     this.story = () => html`<p>Loading...</p>`;
   }
 
+  createRenderRoot() {
+    return this;
+  }
+
   render() {
-    return this.story({ shadowRoot: this.shadowRoot });
+    return this.story({ shadowRoot: this });
   }
 }

--- a/packages/mdjs-story/src/MdJsStory.js
+++ b/packages/mdjs-story/src/MdJsStory.js
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit-element';
+import { LitElement, html } from 'lit';
 
 /**
  * @typedef {object} StoryOptions

--- a/packages/mdjs-story/test-web/mdjs-story.test.js
+++ b/packages/mdjs-story/test-web/mdjs-story.test.js
@@ -1,0 +1,15 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { html as storyHtml } from '@mdjs/mdjs-story';
+
+import '@mdjs/mdjs-story/define';
+
+/** @typedef {import('@mdjs/mdjs-preview').MdJsPreview} MdJsPreview */
+
+describe('mdjs-story', () => {
+  it('will render the element into the light dom by default', async () => {
+    const el = await fixture(html`
+      <mdjs-story .story=${() => storyHtml`<p id="testing"></p>`}></mdjs-story>
+    `);
+    expect(el.querySelectorAll('#testing').length).to.equal(1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,6 +1096,13 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@esm-bundle/chai@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@esm-bundle/chai/-/chai-4.3.4.tgz#74ed4a0794b3a9f9517ff235744ac6f4be0d34dc"
+  integrity sha512-6Tx35wWiNw7X0nLY9RMx8v3EL8SacCFW+eEZOE9Hc+XxmU5HFE2AFEg+GehUZpiyDGwVvPH75ckGlqC7coIPnA==
+  dependencies:
+    "@types/chai" "^4.2.12"
+
 "@lion/accordion@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@lion/accordion/-/accordion-0.4.2.tgz#efeb56360113a2b68e182ff29ef0932edd17df8c"
@@ -1157,6 +1164,11 @@
     "@popperjs/core" "^2.5.4"
     singleton-manager "1.4.1"
 
+"@lit/reactive-element@^1.0.0-rc.1", "@lit/reactive-element@^1.0.0-rc.2":
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz#f24dba16ea571a08dca70f1783bd2ca5ec8de3ee"
+  integrity sha512-cujeIl5Ei8FC7UHf4/4Q3bRJOtdTe1vpJV/JEBYCggedmQ+2P8A2oz7eE+Vxi6OJ4nc0X+KZxXnBoH4QrEbmEQ==
+
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@manypkg/find-root/-/find-root-1.1.0.tgz#a62d8ed1cd7e7d4c11d9d52a8397460b5d4ad29f"
@@ -1212,7 +1224,7 @@
   resolved "https://registry.yarnpkg.com/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.0.tgz#0df5d438285fc3482838786ee81895318f0ff778"
   integrity sha512-UfdK1MPnR6T7f3svzzYBfu3qBkkZ/KsPhcpc3JYhsUY4hbpwNF9wEQtD4Z+/mRqMTJrKg++YSxIxE0FBhY3RIw==
 
-"@open-wc/scoped-elements@^1.2.4", "@open-wc/scoped-elements@^1.3.2":
+"@open-wc/scoped-elements@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-1.3.2.tgz#6ae54c49731bbe8c3e0b5383c989f983dcdfacf5"
   integrity sha512-DoP3XA8r03tGx+IrlJwP/voLuDFkyS56kvwhmXIhpESo7M5jMt5e0zScNrawj7EMe4b5gDaJjorx2Jza8FLaLw==
@@ -1228,6 +1240,15 @@
     "@open-wc/dedupe-mixin" "^1.3.0"
     lit-html "^1.0.0"
 
+"@open-wc/scoped-elements@^2.0.0-next.0":
+  version "2.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-2.0.0-next.3.tgz#adbd9d6fddc67158fd11ffe78c5e11aefdaaf8af"
+  integrity sha512-9dT+0ea/RKO3s2m5H+U8gwG7m1jE89JhgWKI6FnkG4pE9xMx8KACoLZZcUfogVjb6/vKaIeoCj6Mqm+2HiqCeQ==
+  dependencies:
+    "@lit/reactive-element" "^1.0.0-rc.1"
+    "@open-wc/dedupe-mixin" "^1.3.0"
+    "@webcomponents/scoped-custom-element-registry" "0.0.1"
+
 "@open-wc/semantic-dom-diff@^0.13.16":
   version "0.13.21"
   resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.13.21.tgz#718b9ec5f9a98935fc775e577ad094ae8d8b7dea"
@@ -1240,32 +1261,29 @@
   dependencies:
     "@types/chai" "^4.2.11"
 
-"@open-wc/testing-helpers@^1.8.12":
-  version "1.8.12"
-  resolved "https://registry.yarnpkg.com/@open-wc/testing-helpers/-/testing-helpers-1.8.12.tgz#449865689b0283c117326c1e0975834406bb0855"
-  integrity sha512-+4exEHYvnFqI1RGDDIKFHPZ7Ws5NK1epvEku3zLaOYN3zc+huX19SndNc5+X++v8A+quN/iXbHlh80ROyNaYDA==
+"@open-wc/testing-helpers@^2.0.0-next.0":
+  version "2.0.0-next.0"
+  resolved "https://registry.yarnpkg.com/@open-wc/testing-helpers/-/testing-helpers-2.0.0-next.0.tgz#ece19e1c22ff91ae5f6ff2fae199719b7a7bfce7"
+  integrity sha512-94TL8IK05w1JyN8xt7t+vQBQYPdPy/JSJbWJ/ytvStou085SoDN6p1xCPh1PNhjm9LALc60nWM8qb2J2YRT8QA==
   dependencies:
-    "@open-wc/scoped-elements" "^1.2.4"
-    lit-element "^2.2.1"
-    lit-html "^1.0.0"
+    "@open-wc/scoped-elements" "^2.0.0-next.0"
+    lit "^2.0.0-rc.1"
 
-"@open-wc/testing@^2.5.32":
-  version "2.5.32"
-  resolved "https://registry.yarnpkg.com/@open-wc/testing/-/testing-2.5.32.tgz#8bbb65773f650deff06b06277df8cdacd4d6806f"
-  integrity sha512-vl8VwTG3CVLwLcd1mpts8D9xPptc6xPL/9AHEbQxX1IQsFBEiFQdARSp1+V/i7gK2+peXeotqrZ5NvoHxl/lLw==
+"@open-wc/testing@^3.0.0-next.1":
+  version "3.0.0-next.1"
+  resolved "https://registry.yarnpkg.com/@open-wc/testing/-/testing-3.0.0-next.1.tgz#c5c08093439450ed2c871ad18a7ccef787ea15f4"
+  integrity sha512-dDgbqIgNTizSugrya6iSh9s3VS2xsZ3HURFpRVTlKGbEE7OYrRHcBBe73DiSWLRPeYyagVZsOshTUPfTBGamwQ==
   dependencies:
+    "@esm-bundle/chai" "^4.3.4"
     "@open-wc/chai-dom-equals" "^0.12.36"
     "@open-wc/semantic-dom-diff" "^0.19.3"
-    "@open-wc/testing-helpers" "^1.8.12"
+    "@open-wc/testing-helpers" "^2.0.0-next.0"
     "@types/chai" "^4.2.11"
     "@types/chai-dom" "^0.0.9"
-    "@types/mocha" "^5.0.0"
+    "@types/mocha" "^5.2.7"
     "@types/sinon-chai" "^3.2.3"
-    chai "^4.2.0"
     chai-a11y-axe "^1.3.1"
-    chai-dom "^1.8.1"
     mocha "^6.2.2"
-    sinon-chai "^3.3.0"
 
 "@popperjs/core@^2.5.4":
   version "2.6.0"
@@ -1403,6 +1421,11 @@
   version "4.2.14"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
   integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
+
+"@types/chai@^4.2.12":
+  version "4.2.18"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.18.tgz#0c8e298dbff8205e2266606c1ea5fbdba29b46e4"
+  integrity sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==
 
 "@types/command-line-args@^5.0.0":
   version "5.0.0"
@@ -1550,7 +1573,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/mocha@^5.0.0":
+"@types/mocha@^5.2.7":
   version "5.2.7"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
@@ -1639,6 +1662,11 @@
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz#3a84cf5ec3249439015e14049bd3161419bf9eae"
   integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
+
+"@types/trusted-types@^1.0.1":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"
@@ -1959,6 +1987,11 @@
     globby "^11.0.1"
     portfinder "^1.0.28"
     source-map "^0.7.3"
+
+"@webcomponents/scoped-custom-element-registry@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@webcomponents/scoped-custom-element-registry/-/scoped-custom-element-registry-0.0.1.tgz#196365260a019f87bddbded154ab09faf0e666fc"
+  integrity sha512-ef5/v4U2vCxrnSMpo41LSWTjBOXCQ4JOt4+Y6PaSd8ympYioPhOP6E1tKmIk2ppwLSjCKbTyYf7ocHvwDat7bA==
 
 "@webcomponents/webcomponentsjs@^2.5.0":
   version "2.5.0"
@@ -2625,11 +2658,6 @@ chai-a11y-axe@^1.3.1:
   integrity sha512-O+JJ+fELEvK/5SwFe9ltIk+qYz9p+zjnw/iUC1qNrlpgEPvTxScvyvQSU7eP73ixxHkCH1oNFAqkiM+MopbCEw==
   dependencies:
     axe-core "^4.0.2"
-
-chai-dom@^1.8.1:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/chai-dom/-/chai-dom-1.8.2.tgz#e06353baeafa8fddaaabda96a67f859c111a3c7c"
-  integrity sha512-kk2SnCuJliouO5M58OjA7M8VXN338WAxHOm+LbpjeL09pJgRpXugSC5aj8uwFm/6Lmpcdtq7hf+DldTdBm5/Sw==
 
 chai@^4.2.0:
   version "4.2.0"
@@ -5370,17 +5398,41 @@ listr2@^3.2.2:
     rxjs "^6.6.3"
     through "^2.3.8"
 
-lit-element@^2.0.1, lit-element@^2.2.1, lit-element@^2.4.0, lit-element@~2.4.0:
+lit-element@^2.0.1, lit-element@^2.4.0, lit-element@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.4.0.tgz#b22607a037a8fc08f5a80736dddf7f3f5d401452"
   integrity sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==
   dependencies:
     lit-html "^1.1.1"
 
+lit-element@^3.0.0-rc.2:
+  version "3.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.0.0-rc.2.tgz#883d0b6fd7b846226d360699d1b713da5fc7e1b7"
+  integrity sha512-2Z7DabJ3b5K+p5073vFjMODoaWqy5PIaI4y6ADKm+fCGc8OnX9fU9dMoUEBZjFpd/bEFR9PBp050tUtBnT9XTQ==
+  dependencies:
+    "@lit/reactive-element" "^1.0.0-rc.2"
+    lit-html "^2.0.0-rc.3"
+
 lit-html@^1.0.0, lit-html@^1.1.1, lit-html@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
   integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
+
+lit-html@^2.0.0-rc.3:
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.0-rc.3.tgz#1c216e548630e18d3093d97f4e29563abce659af"
+  integrity sha512-Y6P8LlAyQuqvzq6l/Nc4z5/P5M/rVLYKQIRxcNwSuGajK0g4kbcBFQqZmgvqKG+ak+dHZjfm2HUw9TF5N/pkCw==
+  dependencies:
+    "@types/trusted-types" "^1.0.1"
+
+lit@^2.0.0-rc.1, lit@^2.0.0-rc.2:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.0-rc.2.tgz#724a2d621aa098001d73bf7106f3a72b7b5948ef"
+  integrity sha512-BOCuoJR04WaTV8UqTKk09cNcQA10Aq2LCcBOiHuF7TzWH5RNDsbCBP5QM9sLBSotGTXbDug/gFO08jq6TbyEtw==
+  dependencies:
+    "@lit/reactive-element" "^1.0.0-rc.2"
+    lit-element "^3.0.0-rc.2"
+    lit-html "^2.0.0-rc.3"
 
 load-json-file@^4.0.0:
   version "4.0.0"
@@ -7694,11 +7746,6 @@ singleton-manager@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/singleton-manager/-/singleton-manager-1.4.1.tgz#0a9cd1db2b26e5cbc4ecdc20d5a16f284b36aabb"
   integrity sha512-HOvKT/WcHvl2cLYGqmO6MaC2J4wAA82LntGwtLn6avnTq15UDLCnSRVXedmglVooLbQGVsQJ+dQz2sKz+2GUZA==
-
-sinon-chai@^3.3.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.5.0.tgz#c9a78304b0e15befe57ef68e8a85a00553f5c60e"
-  integrity sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==
 
 sinon@^9.2.3:
   version "9.2.3"


### PR DESCRIPTION
## What I did

1. @mdjs/mdjs-preview, @mdjs/mdjs-story
**BREAKING CHANGE** Update to [lit](https://lit.dev/) 2

If your main lit-html version is 1.x be sure to import html for your story rendering from `@mdjs/mdjs-preview`.

````md
```js script
import { html } from '@mdjs/mdjs-preview';
```

```js preview-story
export const foo = () => html`<demo-element></demo-element>`;
```
````

2. @mdjs/mdjs-preview, @mdjs/mdjs-story
**BREAKING CHANGE** Render stories to light dom

```js
export const story = html`<p>my story</p>`;
```

```html
<!-- before -->
<mdjs-story>
  #shadow-root (open)
    <p>my story</p>
</mdjs-story>

<!-- after -->
<mdjs-story>
  <p>my story</p>
</mdjs-story>
```

3. @mdjs/core
**BREAKING CHANGE** by updating dependencies
