### PR TITLE
Use file extension rather than a trailing slash

### DIFF
--- a/packages/check-html-links/src/validateFolder.js
+++ b/packages/check-html-links/src/validateFolder.js
@@ -203,7 +203,7 @@ async function resolveLinks(links, { htmlFilePath, rootDir, ignoreUsage }) {
       anchor,
     };
 
-    let valueFile = value.endsWith('/') ? path.join(value, 'index.html') : value;
+    let valueFile = !path.extname(value) ? path.join(value, 'index.html') : value;
 
     if (ignoreUsage(value)) {
       // ignore


### PR DESCRIPTION
Fixes #124 

The link checker tool gives error for directory links (pretty urls) without the trailing slash (links to /foo instead of /foo/ ). I'd suggest to fix it by checking the presence of file extension rather than trailing slash.
