### PR TITLE
feat(launch): load used fonts from google fonts

### DIFF
--- a/.changeset/mighty-books-guess.md
+++ b/.changeset/mighty-books-guess.md
@@ -1,0 +1,5 @@
+---
+'@rocket/launch': patch
+---
+
+add used fonts from google fonts

--- a/docs/_includes/_joiningBlocks/head/site.njk
+++ b/docs/_includes/_joiningBlocks/head/site.njk
@@ -1,11 +1,3 @@
-<link
-  href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap"
-  rel="stylesheet"
-/>
-<link
-  href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap"
-  rel="stylesheet"
-/>
 <meta name="twitter:creator" content="@modern_web_dev" />
 
 <link rel="stylesheet" href="{{ '/_assets/body.css' | asset | url }}" mdjs-use>

--- a/packages/launch/preset/_includes/_joiningBlocks/head/40-stylesheets-fonts.njk
+++ b/packages/launch/preset/_includes/_joiningBlocks/head/40-stylesheets-fonts.njk
@@ -1,0 +1,10 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+
+<link
+  href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&amp;display=optional"
+  rel="stylesheet"
+/>
+<link
+  href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&amp;display=optional"
+  rel="stylesheet"
+/>


### PR DESCRIPTION
## What I did

1. Load Open Sans and Monserrat from google fonts.
2. Add preconnect lint to reduce time to load fonts
3. Load fonts with `display: optional` as recommend post added on #36
4. Remove fonts from docs/_includes/*/site.njk

Fix #36 
