### PR TITLE
fix(launch): remove footer urls that require user creation

### DIFF
--- a/.changeset/mean-mangos-clap.md
+++ b/.changeset/mean-mangos-clap.md
@@ -1,0 +1,5 @@
+---
+'@rocket/launch': patch
+---
+
+Remove footer urls to pages that users would need to create

--- a/packages/launch/preset/_data/footer.json
+++ b/packages/launch/preset/_data/footer.json
@@ -3,10 +3,6 @@
     "name": "Discover",
     "children": [
       {
-        "text": "Blog",
-        "href": "/blog/"
-      },
-      {
         "text": "Help and Feedback",
         "href": "https://github.com/modernweb-dev/rocket/issues"
       }
@@ -23,19 +19,11 @@
         "text": "Twitter",
         "href": "https://twitter.com/modern_web_dev"
       },
-      {
-        "text": "Slack",
-        "href": "/about/slack/"
-      }
     ]
   },
   {
     "name": "Support",
     "children": [
-      {
-        "text": "Sponsor",
-        "href": "/about/sponsor/"
-      },
       {
         "text": "Contribute",
         "href": "https://github.com/modernweb-dev/rocket/blob/master/CONTRIBUTING.md"


### PR DESCRIPTION
## What I did

1. Remove footer urls to pages that users would need to create

closes https://github.com/modernweb-dev/rocket/issues/188
closes https://github.com/modernweb-dev/rocket/issues/124
