### PR TITLE
fix(launch): create help & feedback link only if site.helpUrl is defined

### DIFF
--- a/.changeset/early-pots-guess.md
+++ b/.changeset/early-pots-guess.md
@@ -1,0 +1,5 @@
+---
+'@rocket/launch': patch
+---
+
+Only show the help & feedback link if a site.helpUrl is defined

--- a/packages/launch/preset/_includes/partials/mobile-sidebar-bottom.njk
+++ b/packages/launch/preset/_includes/partials/mobile-sidebar-bottom.njk
@@ -1,6 +1,6 @@
 <div class="sidebar-bottom">
-  <hr>
-  {% include 'partials/_shared/darkSwitch.njk' %}
-
-  <a href="{{ site.helpUrl | url }}">Help and Feedback</a>
+  <hr/> {% include 'partials/_shared/darkSwitch.njk' %}
+  {% if site.helpUrl %}
+    <a href="{{ site.helpUrl | url }}">Help and Feedback</a>
+  {% endif %}
 </div>


### PR DESCRIPTION
## What I did

1. Only show the help & feedback link if a site.helpUrl is defined

closes https://github.com/modernweb-dev/rocket/issues/103