### PR TITLE
fix: ignore includes

### DIFF
--- a/packages/cli/preset/.eleventyignore
+++ b/packages/cli/preset/.eleventyignore
@@ -1,0 +1,4 @@
+_includes
+_merged_includes
+_assets
+_merged_assets


### PR DESCRIPTION
Prevents error when extracting assets

## What I did

1. add `.eleventyignore` to cli preset
