### PR TITLE
docs: prevent error on build

### DIFF
--- a/docs/guides/presets/using-templates.md
+++ b/docs/guides/presets/using-templates.md
@@ -6,6 +6,19 @@ On top of the [Overriding](./overriding.md) you can do with the presets alone te
 
 It is generally preferred to use `Joining Blocks` before overriding.
 
+<inline-notification type="danger">
+
+  You may receive error messages when running `rocket build` if you add your own joining blocks. To avoid them, add a `docs/.eleventyignore` with
+  
+  ```
+  _includes
+  _merged_includes
+  _assets
+  _merged_assets
+  ```
+  
+</inline-notification>
+
 ## Adding html to the html head
 
 Often you will want to load some more fonts or an additional CSS file. You can do so by adding a file to the head Joining Block.


### PR DESCRIPTION
see #205

## What I did

1. document how to ignore includes during build

We should fix this with the https://www.11ty.dev/docs/ignores/#configuration-api javascript ignores API when we migrate to v1.0
