### PR TITLE
fix: use semver to lint versions

### DIFF
--- a/scripts/lint-versions.js
+++ b/scripts/lint-versions.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readdirSync, existsSync, readFileSync } from 'fs';
+import semver from 'semver';
 
 const getDirectories = source =>
   readdirSync(source, { withFileTypes: true })
@@ -35,7 +36,12 @@ function compareVersions(versionsA, versionsB) {
   let output = '';
   const newVersions = { ...versionsA };
   Object.keys(versionsB).forEach(dep => {
-    if (versionsA[dep] && versionsB[dep] && versionsA[dep] !== versionsB[dep]) {
+    if (
+      versionsA[dep] &&
+      versionsB[dep] &&
+      versionsA[dep] !== versionsB[dep] &&
+      !semver.satisfies(versionsA[dep], versionsB[dep])
+    ) {
       output += `  - "${dep}" should be "${versionsA[dep]}" but is "${versionsB[dep]}"\n`;
     }
     if (!newVersions[dep]) {


### PR DESCRIPTION
## What I did

1. Fix version number of internal packages

### Why

When an internal package is updated dependant packages are not updated. Fixing version number instead of using `^` allows changeset to update versions of related packages, and publish all changed packages and their dependants.

Actually, every version update breaks all PR because of the version linter. With this will be aligned all version on each publish