### PR TITLE
fix(cli): set the encoding of the simulator to utf8

### DIFF
--- a/.changeset/shiny-swans-drop.md
+++ b/.changeset/shiny-swans-drop.md
@@ -1,0 +1,5 @@
+---
+'@rocket/cli': patch
+---
+
+Set the encoding of the simulator to utf8 via a html meta tag

--- a/packages/cli/preset/_includes/layout-simulator.njk
+++ b/packages/cli/preset/_includes/layout-simulator.njk
@@ -1,6 +1,7 @@
 <html theme="light" platform="web" lang="en">
   <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8">
     <style type="text/css">
       body {
         margin: 0;


### PR DESCRIPTION
## What I did

1. Set the encoding of the simulator to utf8 via a html meta tag
