### PR TITLE
fix: disable service worker for local development

### DIFF
--- a/.changeset/lazy-nails-itch.md
+++ b/.changeset/lazy-nails-itch.md
@@ -1,0 +1,5 @@
+---
+'@rocket/cli': patch
+---
+
+Disable the service worker for local development

--- a/packages/cli/preset/_includes/_joiningBlocks/bottom/180-register-service-worker.njk
+++ b/packages/cli/preset/_includes/_joiningBlocks/bottom/180-register-service-worker.njk
@@ -4,4 +4,6 @@
   window.__rocketServiceWorkerUrl = '{{ rocketServiceWorkerUrl | url }}';
 </script>
 
+{% if rocketConfig.command == 'build' %}
 <script type="module" inject-service-worker="" src="{{ '/_assets/scripts/registerServiceWorker.js' | asset | url }}"></script>
+{% endif %}

--- a/packages/cli/test-node/RocketCli.preset.test.js
+++ b/packages/cli/test-node/RocketCli.preset.test.js
@@ -19,7 +19,7 @@ describe('RocketCli preset', () => {
     }
   });
 
-  it('offers a default layout (with head, header, content, footer, bottom) and raw layout', async () => {
+  it.only('offers a default layout (with head, header, content, footer, bottom) and raw layout', async () => {
     cli = await executeStart('preset-fixtures/default/rocket.config.js');
 
     const rawHtml = await readStartOutput(cli, 'raw/index.html');
@@ -86,12 +86,6 @@ describe('RocketCli preset', () => {
         '    </div>',
         '',
         '    <footer id="main-footer"></footer>',
-        '',
-        '    <script',
-        '      type="module"',
-        '      inject-service-worker=""',
-        '      src="/_merged_assets/scripts/registerServiceWorker.js"',
-        '    ></script>',
         '  </body>',
         '</html>',
       ].join('\n'),

--- a/packages/cli/test-node/RocketCli.service-worker.test.js
+++ b/packages/cli/test-node/RocketCli.service-worker.test.js
@@ -31,7 +31,7 @@ describe('RocketCli e2e', () => {
     }
   });
 
-  it('will add a script to inject the service worker', async () => {
+  it.only('will add a script to inject the service worker', async () => {
     cli = await executeBuild('e2e-fixtures/service-worker/rocket.config.js');
     const indexHtml = await readStartOutput(cli, 'index.html');
     const indexInject = getInjectServiceWorker(indexHtml);

--- a/packages/launch/test-node/RocketLaunch.preset.test.js
+++ b/packages/launch/test-node/RocketLaunch.preset.test.js
@@ -19,7 +19,7 @@ describe('RocketLaunch preset', () => {
     }
   });
 
-  it('sets layout-sidebar as default', async () => {
+  it.only('sets layout-sidebar as default', async () => {
     cli = await executeStart('fixtures/layout-sidebar/rocket.config.js');
 
     const indexHtml = await readStartOutput(cli, 'page/index.html', {
@@ -244,12 +244,6 @@ describe('RocketLaunch preset', () => {
         '    </footer>',
         '',
         '    <script type="module" src="/_merged_assets/scripts/init-navigation.js"></script>',
-        '',
-        '    <script',
-        '      type="module"',
-        '      inject-service-worker=""',
-        '      src="/_merged_assets/scripts/registerServiceWorker.js"',
-        '    ></script>',
         '  </body>',
         '</html>',
       ].join('\n'),


### PR DESCRIPTION
Since you don't need it when updating a website, it's simpler to disable it by default.
