### PR TITLE
Fixed typo pnpx start -> pnpm start

### DIFF
--- a/docs/guides/first-pages/getting-started.md
+++ b/docs/guides/first-pages/getting-started.md
@@ -159,7 +159,7 @@ yarn start
 ```
 
 ```bash tab pnpm
-pnpx start
+pnpm start
 ```
 
 </code-tabs>

--- a/docs/guides/first-pages/getting-started.md
+++ b/docs/guides/first-pages/getting-started.md
@@ -42,15 +42,15 @@ pnpm init -y
 <code-tabs collection="package-managers" default-tab="npm" align="end">
 
 ```bash tab npm
-npm install --save-dev @rocket/cli @rocket/launch
+npm install --save-dev @rocket/cli @rocket/drawer @rocket/launch @rocket/navigation
 ```
 
 ```bash tab yarn
-yarn add -D @rocket/cli @rocket/launch
+yarn add -D @rocket/cli @rocket/drawer @rocket/launch @rocket/navigation
 ```
 
 ```bash tab pnpm
-pnpm add -D @rocket/cli @rocket/launch
+pnpm add -D @rocket/cli @rocket/drawer @rocket/launch @rocket/navigation
 ```
 
 </code-tabs>


### PR DESCRIPTION
Analog to npm, the rocket start must be triggered using pnpm _not_ pnpx.

## What I did

1. Fixed the typo ;-)
