### PR TITLE
chore(mdjs-preview): removed reflection of theme attribute

### DIFF
--- a/.changeset/ninety-news-admire.md
+++ b/.changeset/ninety-news-admire.md
@@ -1,0 +1,5 @@
+---
+'@mdjs/mdjs-preview': patch
+---
+
+Removed reflect of thetheme attribute

--- a/packages/mdjs-preview/src/MdJsPreview.js
+++ b/packages/mdjs-preview/src/MdJsPreview.js
@@ -51,7 +51,7 @@ export class MdJsPreview extends ScopedElementsMixin(LitElement) {
       platforms: { type: Array },
       size: { type: String },
       sizes: { type: Array },
-      theme: { type: String, reflect: true },
+      theme: { type: String },
       themes: { type: Array },
       language: { type: String },
       languages: { type: Array },


### PR DESCRIPTION
## What I did

1. Removed reflect of the`theme` attribute, since it also changed the dark/light-mode styling of the buttons and links inside the mdjs-preview of our portal.
