### PR TITLE
fix: improve mdjs preview iframe security

### DIFF
--- a/.changeset/strange-clouds-grab.md
+++ b/.changeset/strange-clouds-grab.md
@@ -1,0 +1,6 @@
+---
+'@rocket/cli': patch
+'@mdjs/mdjs-preview': patch
+---
+
+Enable including script files into the simulator via `<script src=".." mdjs-use>`

--- a/.changeset/strange-clouds-grab2.md
+++ b/.changeset/strange-clouds-grab2.md
@@ -1,0 +1,10 @@
+---
+'@rocket/cli': patch
+'@mdjs/mdjs-preview': patch
+---
+
+Allow only a limited set of characters for simulator includes `[a-zA-Z0-9\/\-_]`.
+Notably, there is no:
+
+- `:` to prevent `http://...` includes
+- `.` so filenames as `this.is.my.js` are not supported. Also includes will be without file endings which will be added automatically

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' www.googletagmanager.com 'sha256-W6Gq+BvrdAAMbF8E7WHA7UPQxuUOfJM8E9mpKD0oihA=' 'sha256-vFU+IJ5dUUukI5Varwy49dN2d89DmFj7UNewqQv88sw='; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' data: fonts.gstatic.com;"

--- a/packages/cli/preset/_includes/layout-simulator.njk
+++ b/packages/cli/preset/_includes/layout-simulator.njk
@@ -14,19 +14,37 @@
     <script type="module">
       import { render } from '@mdjs/mdjs-story';
 
+      function sanitize(input, type) {
+        return `${document.location.origin}/${input.match(/[a-zA-Z0-9\/\-_]*/)[0]}.${type}`;
+      }
+
       async function onHashChange() {
         const urlParts = new URLSearchParams(document.location.hash.substr(1));
 
         if (urlParts.get('stylesheets')) {
           for (const stylesheet of urlParts.getAll('stylesheets')) {
-            if (!document.querySelector(`link[rel="stylesheet"][href="${stylesheet}"]`)) {
+            const safeStylesheetUrl = sanitize(stylesheet, 'css');
+            if (!document.querySelector(`link[rel="stylesheet"][href="${safeStylesheetUrl}"]`)) {
               const link = document.createElement('link');
               link.rel = 'stylesheet';
-              link.href = stylesheet;
+              link.href = safeStylesheetUrl;
               document.head.appendChild(link);
             }
           }
         }
+
+        if (urlParts.get('moduleUrls')) {
+          for (const moduleUrl of urlParts.getAll('moduleUrls')) {
+            const safeModuleUrl = sanitize(moduleUrl, 'js');
+            if (!document.querySelector(`script[type=module][src="${safeModuleUrl}"]`)) {
+              const script = document.createElement('script');
+              script.type = 'module';
+              script.src = safeModuleUrl;
+              document.head.appendChild(script);
+            }
+          }
+        }
+
         if (urlParts.get('theme')) {
           document.documentElement.setAttribute('theme', urlParts.get('theme'));
         }
@@ -46,7 +64,8 @@
           document.documentElement.removeAttribute('edge-distance');
         }
 
-        const mod = await import(urlParts.get('story-file'));
+        const safeStoryUrl = sanitize(urlParts.get('story-file'), 'js');
+        const mod = await import(safeStoryUrl);
         render(mod[urlParts.get('story-key')]({ shadowRoot: document }), document.body);
       }
 

--- a/packages/mdjs-preview/src/MdJsPreview.js
+++ b/packages/mdjs-preview/src/MdJsPreview.js
@@ -11,6 +11,16 @@ import {
 import { addResizeHandler } from './resizeHandler.js';
 
 /**
+ * @param {string} input
+ * @param {'js'|'css'} type
+ * @returns {string}
+ */
+function sanitize(input, type) {
+  const url = new URL(input);
+  return url.pathname.slice(1, (type.length + 1) * -1);
+}
+
+/**
  * @typedef {object} StoryOptions
  * @property {HTMLElement | null} StoryOptions.shadowRoot
  */
@@ -273,9 +283,8 @@ export class MdJsPreview extends ScopedElementsMixin(LitElement) {
     if (!mdjsSetupScript) {
       throw new Error('Could not find a <script type="module" src="..." mdjs-setup></script>');
     }
-
     const params = new URLSearchParams();
-    params.set('story-file', mdjsSetupScript.src);
+    params.set('story-file', sanitize(mdjsSetupScript.src, 'js'));
     params.set('story-key', this.key);
     params.set('theme', this.theme);
     params.set('platform', this.platform);
@@ -287,7 +296,16 @@ export class MdJsPreview extends ScopedElementsMixin(LitElement) {
     ]);
     for (const link of links) {
       if (link.href) {
-        params.append('stylesheets', link.href);
+        params.append('stylesheets', sanitize(link.href, 'css'));
+      }
+    }
+
+    const moduleUrls = /** @type {HTMLScriptElement[]} */ ([
+      ...document.querySelectorAll('script[type=module][mdjs-use]'),
+    ]);
+    for (const moduleUrl of moduleUrls) {
+      if (moduleUrl.src) {
+        params.append('moduleUrls', sanitize(moduleUrl.src, 'js'));
       }
     }
 


### PR DESCRIPTION
## What I did

1. Enable including script files into the simulator via `<script src=".." mdjs-use>`
2. Allow only a limited set of characters for simulator includes `[a-zA-Z0-9\/\-_]`.
Notably, there is no:

- `:` to prevent `http://...` includes
- `.` so filenames as `this.is.my.js` are not supported. Also includes will be without file endings which will be added automatically


