### PR TITLE
fix(drawer): add export map with /define side effect import

### DIFF
--- a/.changeset/rare-toys-battle.md
+++ b/.changeset/rare-toys-battle.md
@@ -1,0 +1,5 @@
+---
+'@rocket/drawer': patch
+---
+
+Add export map which enables side effect import via `@rocket/drawer/define`

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -13,6 +13,11 @@
   },
   "author": "Modern Web <hello@modern-web.dev> (https://modern-web.dev/)",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./rocket-drawer.js": "./rocket-drawer.js",
+    "./define": "./rocket-drawer.js"
+  },
   "scripts": {
     "dev": "web-dev-server --node-resolve --root-dir ../../ --open packages/drawer/ --watch",
     "rocket:build": "node src/build/cli.js -c demo/docs",


### PR DESCRIPTION
## What I did

1. Add export map which enables side effect import via `@rocket/drawer/define`
