### PR TITLE
feat(mdjs-core): support `js client` as an alias to `js script`

### DIFF
--- a/.changeset/four-pets-brush.md
+++ b/.changeset/four-pets-brush.md
@@ -1,0 +1,5 @@
+---
+'@mdjs/core': patch
+---
+
+Support `js client` as an alias to `js script`

--- a/packages/mdjs-core/src/mdjsParse.js
+++ b/packages/mdjs-core/src/mdjsParse.js
@@ -16,6 +16,9 @@ function mdjsParse() {
       if (node.lang === 'js' && node.meta === 'script') {
         jsCode += node.value;
       }
+      if (node.lang === 'js' && node.meta === 'client') {
+        jsCode += node.value;
+      }
     });
     // we can only return/modify the tree but jsCode should not be part of the tree
     // so we attach it globally to the file.data
@@ -26,7 +29,9 @@ function mdjsParse() {
      * @param {Node} node
      */
     const removeFunction = node =>
-      node.type === 'code' && node.lang === 'js' && node.meta === 'script';
+      node.type === 'code' &&
+      node.lang === 'js' &&
+      (node.meta === 'script' || node.meta === 'client');
     remove(tree, removeFunction);
 
     return tree;

--- a/packages/mdjs-core/test-node/mdjsParse.test.js
+++ b/packages/mdjs-core/test-node/mdjsParse.test.js
@@ -28,6 +28,24 @@ describe('mdjsParse', () => {
     expect(/** @type {MDJSVFileData} */ (result.data).jsCode).to.equal('const bar = 22;');
   });
 
+  it('extracts "js client" code blocks', async () => {
+    const input = [
+      '## Intro',
+      '```js',
+      'const foo = 1;',
+      '```',
+      '```js client',
+      'const bar = 22;',
+      '```',
+    ].join('\n');
+    const parser = unified().use(markdown).use(mdjsParse).use(html, { sanitize: false });
+    const result = await parser.process(input);
+    expect(result.contents).to.equal(
+      '<h2>Intro</h2>\n<pre><code class="language-js">const foo = 1;\n</code></pre>\n',
+    );
+    expect(/** @type {MDJSVFileData} */ (result.data).jsCode).to.equal('const bar = 22;');
+  });
+
   // TODO: fix this bug - maybe something in unified itself 🤔
   it.skip('handling only "js script" code blocks', async () => {
     const input = [


### PR DESCRIPTION
## What I did

1.
