### PR TITLE
fix(engine): prevent fatal error because of simultaneous write to file

### DIFF
--- a/.changeset/early-shrimps-applaud.md
+++ b/.changeset/early-shrimps-applaud.md
@@ -1,0 +1,9 @@
+---
+'@rocket/engine': patch
+---
+
+Prevent fatal error because of simultaneous write to file.
+
+When the browser requested a file to be rendered and that file also needed an update in the "rocket header" (the top of the file) then it could be that the watcher trigger a simultaneous render of the file while the first render was still in progress.
+
+The solution is that the watcher ignores changes to a file until a full render is finished.

--- a/packages/engine/src/Engine.js
+++ b/packages/engine/src/Engine.js
@@ -444,7 +444,9 @@ export class Engine {
       }
       return result;
     }
-
+    if (this.watcher) {
+      this.watcher.addFileToIgnore(sourceFilePath);
+    }
     if (rocketHeader) {
       const { needsAnotherRenderingPass } = await rocketHeader.syncComponents({
         outputFileContent: result.fileContent,
@@ -460,6 +462,9 @@ export class Engine {
       }
     }
 
+    if (this.watcher) {
+      this.watcher.removeFileToIgnore(sourceFilePath);
+    }
     return result;
   }
 }

--- a/packages/engine/test-node/09b-watch-error-handling.test.js
+++ b/packages/engine/test-node/09b-watch-error-handling.test.js
@@ -114,4 +114,72 @@ describe('Engine start error handling', () => {
     );
     await cleanup();
   });
+
+  it('04: update-header-while-rendering', async () => {
+    const { readOutput, writeSource, cleanup, engine, setAsOpenedInBrowser, outputExists } =
+      await setupTestEngine(
+        'fixtures/09b-watch-error-handling/04-update-header-while-rendering/docs',
+      );
+    await writeSource(
+      'index.rocket.js',
+      [
+        '/* START - Rocket auto generated - do not touch */',
+        "export const sourceRelativeFilePath = 'index.rocket.js';",
+        "import { html, components, layout } from './recursive.data.js';",
+        'export { html, components, layout };',
+        'export async function registerCustomElements() {',
+        '  // hydrate-able components',
+        "  customElements.define('hello-typer', await import('#c/HelloTyper.js').then(m => m.HelloTyper));",
+        '}',
+        'export const needsLoader = true;',
+        '/* END - Rocket auto generated - do not touch */',
+        '',
+        'export default () => html`',
+        '  <h1>Hello World</h1>',
+        '  <hello-typer loading="hydrate:onVisible"></hello-typer>',
+        '`;',
+      ].join('\n'),
+    );
+
+    await engine.start();
+    setAsOpenedInBrowser('index.rocket.js');
+
+    const { port } = engine.devServer.config;
+    expect(outputExists('index.html')).to.be.false;
+    await fetch(`http://localhost:${port}/`);
+
+    expect(readOutput('index.html')).to.equal(
+      [
+        '<!DOCTYPE html>',
+        '<html lang="en">',
+        '  <head>',
+        '    <meta charset="utf-8" />',
+        '  </head>',
+        '  <body>',
+        '    <h1>Hello World</h1>',
+        '    <hello-typer loading="hydrate:onVisible"',
+        '      ><template shadowroot="open"',
+        '        ><style>',
+        '          button {',
+        '            font-size: 200%;',
+        '            width: 64px;',
+        '            height: 64px;',
+        '            border: none;',
+        '            border-radius: 10px;',
+        '            background-color: seagreen;',
+        '            color: white;',
+        '          }',
+        '        </style>',
+        '        <p>🤔 Hello <span> </span></p>',
+        '        <button>+</button>',
+        '      </template></hello-typer',
+        '    >',
+        '    <script type="module" src="index-loader-generated.js"></script>',
+        '  </body>',
+        '</html>',
+      ].join('\n'),
+    );
+
+    await cleanup();
+  });
 });

--- a/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/components/HelloTyper.js
+++ b/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/components/HelloTyper.js
@@ -1,0 +1,54 @@
+import { LitElement, html, css } from 'lit';
+
+let i = 0;
+const fullText = [...'to this wonderful world of progressive hydration 🤯'];
+
+export class HelloTyper extends LitElement {
+  static properties = {
+    msg: { type: String },
+    counter: { type: Number },
+  };
+
+  constructor() {
+    super();
+    this.msg = ' ';
+    this.counter = 0;
+  }
+
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    if (i < fullText.length) {
+      setTimeout(() => {
+        this.msg += fullText[i];
+        i += 1;
+      }, Math.floor(Math.random() * 50) + 40);
+    }
+  }
+
+  render() {
+    return html`
+      <p>🤔 Hello <span>${this.msg}</span>${'🤯'.repeat(this.counter)}</p>
+      <button @click=${this._inc}>+</button>
+    `;
+  }
+
+  _inc() {
+    if (i >= fullText.length) {
+      this.counter += 1;
+    }
+  }
+
+  static styles = [
+    css`
+      button {
+        font-size: 200%;
+        width: 64px;
+        height: 64px;
+        border: none;
+        border-radius: 10px;
+        background-color: seagreen;
+        color: white;
+      }
+    `,
+  ];
+}

--- a/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/docs/index.rocket.js
+++ b/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/docs/index.rocket.js
@@ -1,0 +1,15 @@
+/* START - Rocket auto generated - do not touch */
+export const sourceRelativeFilePath = 'index.rocket.js';
+import { html, components, layout } from './recursive.data.js';
+export { html, components, layout };
+export async function registerCustomElements() {
+  // hydrate-able components
+  customElements.define('hello-typer', await import('#c/HelloTyper.js').then(m => m.HelloTyper));
+}
+export const needsLoader = true;
+/* END - Rocket auto generated - do not touch */
+
+export default () => html`
+  <h1>Hello World</h1>
+  <hello-typer loading="hydrate:onVisible"></hello-typer>
+`;

--- a/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/docs/pageTreeData.rocketGenerated.json
+++ b/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/docs/pageTreeData.rocketGenerated.json
@@ -1,0 +1,22 @@
+{
+  "url": "/",
+  "outputRelativeFilePath": "index.html",
+  "sourceRelativeFilePath": "index.rocket.js",
+  "level": 0,
+  "children": [
+    {
+      "url": "/about/",
+      "outputRelativeFilePath": "about/index.html",
+      "sourceRelativeFilePath": "about.rocket.js",
+      "level": 1
+    }
+  ],
+  "menuLinkText": "Hello World",
+  "name": "Hello World",
+  "title": "name is not defined",
+  "h1": "Hello World",
+  "components": {
+    "hello-typer": "#c/HelloTyper.js::HelloTyper"
+  },
+  "needsLoader": true
+}

--- a/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/docs/recursive.data.js
+++ b/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/docs/recursive.data.js
@@ -1,0 +1,19 @@
+import { html } from 'lit';
+
+export { html };
+
+export const components = {
+  'hello-typer': '#c/HelloTyper.js::HelloTyper',
+};
+
+export const layout = data => html`
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+    </head>
+    <body>
+      ${data.content()}
+    </body>
+  </html>
+`;

--- a/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/package.json
+++ b/packages/engine/test-node/fixtures/09b-watch-error-handling/04-update-header-while-rendering/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/components",
+  "type": "module",
+  "imports": {
+    "#c/*": "./components/*"
+  }
+}


### PR DESCRIPTION
## What I did

1. Prevent fatal error because of simultaneous write to file.

When the browser requested a file to be rendered and that file also needed an update in the "rocket header" (the top of the file) then it could be that the watcher trigger a simultaneous render of the file while the first render was still in progress.

The solution is that the watcher ignores changes to a file until a full render is finished.

fixes https://github.com/modernweb-dev/rocket/issues/375
