### PR TITLE
feat: improve menu parsing to enable html and renaming

### DIFF
--- a/.changeset/many-pigs-admire.md
+++ b/.changeset/many-pigs-admire.md
@@ -1,0 +1,9 @@
+---
+'@rocket/engine': patch
+---
+
+HTML in headings will be ignored for the menu
+Some examples:
+
+- `<h1>Hello <em>Word</em></h1>` => `Hello Word`
+- `<h1>Hello <strong>World</strong> of <span>JS <em>(JavaScript)</em></span>!</h1>` => `Hello World of JS (JavaScript)!`

--- a/.changeset/silly-islands-sparkle.md
+++ b/.changeset/silly-islands-sparkle.md
@@ -1,0 +1,13 @@
+---
+'@rocket/engine': patch
+---
+
+Menus now support special characters in markdown headings.
+
+Examples:
+
+```md
+# Fun Errors & Feedback
+
+# &lt;some-button>
+```

--- a/packages/engine/src/web-menu/getHtmlMetaData.js
+++ b/packages/engine/src/web-menu/getHtmlMetaData.js
@@ -82,7 +82,11 @@ export function getHtmlMetaData(htmlFilePath) {
       if (isHeadline(data)) {
         const id = getAttribute(data, 'id');
         const linkText = getAttribute(data, 'link-text');
-        const text = linkText || capturedHeadlineText || '';
+        const processedCapturedHeadlineText = capturedHeadlineText
+          ?.replace(/&#x3C;/g, '&lt;')
+          .replace(/&#x26;/g, '&')
+          .trim();
+        const text = linkText || processedCapturedHeadlineText || '';
         if (data.name === 'h1') {
           metaData.h1 = text;
         }
@@ -90,7 +94,7 @@ export function getHtmlMetaData(htmlFilePath) {
           if (!metaData.headlinesWithId) {
             metaData.headlinesWithId = [];
           }
-          const rawTextObj = linkText ? { rawText: capturedHeadlineText } : {};
+          const rawTextObj = linkText ? { rawText: processedCapturedHeadlineText } : {};
           metaData.headlinesWithId.push({
             text,
             id,

--- a/packages/engine/src/web-menu/sax-parser.js
+++ b/packages/engine/src/web-menu/sax-parser.js
@@ -9,6 +9,9 @@ const require = createRequire(import.meta.url);
 export const streamOptions = { highWaterMark: 128 * 1024 };
 const saxPath = require.resolve('sax-wasm/lib/sax-wasm.wasm');
 const saxWasmBuffer = await readFile(saxPath);
-export const parser = new SAXParser(SaxEventType.CloseTag, streamOptions);
+export const parser = new SAXParser(
+  SaxEventType.OpenTag | SaxEventType.CloseTag | SaxEventType.Text,
+  streamOptions,
+);
 
 await parser.prepareWasm(saxWasmBuffer);

--- a/packages/engine/test-node/05z-menu.test.js
+++ b/packages/engine/test-node/05z-menu.test.js
@@ -893,4 +893,40 @@ describe('Engine menus', () => {
       url: '/',
     });
   });
+
+  it('15: link-text attribute', async () => {
+    const { build, readSource } = await setupTestEngine(
+      'fixtures/05-menu/16-link-text-attribute/docs',
+    );
+    await build();
+
+    expect(JSON.parse(readSource('pageTreeData.rocketGenerated.json'))).to.deep.equal({
+      h1: 'Home',
+      headlinesWithId: [
+        {
+          id: 'home',
+          level: 1,
+          rawText: 'Welcome to Rocket',
+          text: 'Home',
+        },
+        {
+          id: 'first',
+          level: 2,
+          text: 'First',
+        },
+        {
+          id: 'second',
+          level: 2,
+          rawText: 'Second is best',
+          text: 'Second',
+        },
+      ],
+      level: 0,
+      menuLinkText: 'Home',
+      name: 'Home',
+      outputRelativeFilePath: 'index.html',
+      sourceRelativeFilePath: 'index.rocket.js',
+      url: '/',
+    });
+  });
 });

--- a/packages/engine/test-node/05z-menu.test.js
+++ b/packages/engine/test-node/05z-menu.test.js
@@ -851,4 +851,46 @@ describe('Engine menus', () => {
       level: 0,
     });
   });
+
+  it('15: markdown special characters', async () => {
+    const { build, readSource } = await setupTestEngine(
+      'fixtures/05-menu/15-md-special-characters/docs',
+    );
+    await build();
+
+    expect(JSON.parse(readSource('pageTreeData.rocketGenerated.json'))).to.deep.equal({
+      children: [
+        {
+          h1: '&lt;some-button>',
+          headlinesWithId: [
+            {
+              id: 'some-button',
+              level: 1,
+              text: '&lt;some-button>',
+            },
+          ],
+          level: 1,
+          menuLinkText: '&lt;some-button>',
+          name: '&lt;some-button>',
+          outputRelativeFilePath: 'component/index.html',
+          sourceRelativeFilePath: 'component.rocket.md',
+          url: '/component/',
+        },
+      ],
+      h1: 'Fun Errors & Feedback',
+      headlinesWithId: [
+        {
+          id: 'fun-errors--feedback',
+          level: 1,
+          text: 'Fun Errors & Feedback',
+        },
+      ],
+      level: 0,
+      menuLinkText: 'Fun Errors & Feedback',
+      name: 'Fun Errors & Feedback',
+      outputRelativeFilePath: 'index.html',
+      sourceRelativeFilePath: 'index.rocket.md',
+      url: '/',
+    });
+  });
 });

--- a/packages/engine/test-node/05z-menu.test.js
+++ b/packages/engine/test-node/05z-menu.test.js
@@ -834,4 +834,21 @@ describe('Engine menus', () => {
 
     await cleanup();
   });
+
+  it('14: get-all-text-but-strip-html', async () => {
+    const { build, readSource } = await setupTestEngine(
+      'fixtures/05-menu/14-get-all-text-but-strip-html/docs',
+    );
+    await build();
+
+    expect(JSON.parse(readSource('pageTreeData.rocketGenerated.json'))).to.deep.equal({
+      h1: 'Hello World of JS (JavaScript)!',
+      name: 'Hello World of JS (JavaScript)!',
+      menuLinkText: 'Hello World of JS (JavaScript)!',
+      url: '/',
+      outputRelativeFilePath: 'index.html',
+      sourceRelativeFilePath: 'index.rocket.js',
+      level: 0,
+    });
+  });
 });

--- a/packages/engine/test-node/09b-watch-error-handling.test.js
+++ b/packages/engine/test-node/09b-watch-error-handling.test.js
@@ -116,10 +116,21 @@ describe('Engine start error handling', () => {
   });
 
   it('04: update-header-while-rendering', async () => {
-    const { readOutput, writeSource, cleanup, engine, setAsOpenedInBrowser, outputExists } =
-      await setupTestEngine(
-        'fixtures/09b-watch-error-handling/04-update-header-while-rendering/docs',
-      );
+    const {
+      readOutput,
+      writeSource,
+      cleanup,
+      engine,
+      setAsOpenedInBrowser,
+      outputExists,
+      anEngineEvent,
+    } = await setupTestEngine(
+      'fixtures/09b-watch-error-handling/04-update-header-while-rendering/docs',
+    );
+    expect(outputExists('index.html')).to.be.false;
+
+    await engine.start();
+    setAsOpenedInBrowser('index.rocket.js');
     await writeSource(
       'index.rocket.js',
       [
@@ -140,13 +151,7 @@ describe('Engine start error handling', () => {
         '`;',
       ].join('\n'),
     );
-
-    await engine.start();
-    setAsOpenedInBrowser('index.rocket.js');
-
-    const { port } = engine.devServer.config;
-    expect(outputExists('index.html')).to.be.false;
-    await fetch(`http://localhost:${port}/`);
+    await anEngineEvent('rocketUpdated');
 
     expect(readOutput('index.html')).to.equal(
       [

--- a/packages/engine/test-node/fixtures/04-layouts/01-function/docs/pageTreeData.rocketGenerated.json
+++ b/packages/engine/test-node/fixtures/04-layouts/01-function/docs/pageTreeData.rocketGenerated.json
@@ -1,15 +1,15 @@
 {
   "title": "Fixed Title",
-  "h1": "\n    Welcome Members:\n  ",
+  "h1": "Welcome Members:",
   "headlinesWithId": [
     {
-      "text": "\n    Welcome Members:\n  ",
+      "text": "Welcome Members:",
       "id": "welcome-members",
       "level": 1
     }
   ],
   "name": "Fixed Title",
-  "menuLinkText": "\n    Welcome Members:\n  ",
+  "menuLinkText": "Welcome Members:",
   "url": "/",
   "outputRelativeFilePath": "index.html",
   "sourceRelativeFilePath": "index.rocket.js",

--- a/packages/engine/test-node/fixtures/05-menu/14-get-all-text-but-strip-html/docs/index.rocket.js
+++ b/packages/engine/test-node/fixtures/05-menu/14-get-all-text-but-strip-html/docs/index.rocket.js
@@ -1,0 +1,11 @@
+/* START - Rocket auto generated - do not touch */
+export const sourceRelativeFilePath = 'index.rocket.js';
+import { layout, html } from './recursive.data.js';
+export { layout, html };
+/* END - Rocket auto generated - do not touch */
+
+export default () =>
+  html`<h1>
+    Hello <strong>World</strong> of <span>JS <em>(JavaScript)</em></span
+    >!
+  </h1>`;

--- a/packages/engine/test-node/fixtures/05-menu/14-get-all-text-but-strip-html/docs/pageTreeData.rocketGenerated.json
+++ b/packages/engine/test-node/fixtures/05-menu/14-get-all-text-but-strip-html/docs/pageTreeData.rocketGenerated.json
@@ -1,0 +1,9 @@
+{
+  "h1": "Hello World of JS (JavaScript)!",
+  "name": "Hello World of JS (JavaScript)!",
+  "menuLinkText": "Hello World of JS (JavaScript)!",
+  "url": "/",
+  "outputRelativeFilePath": "index.html",
+  "sourceRelativeFilePath": "index.rocket.js",
+  "level": 0
+}

--- a/packages/engine/test-node/fixtures/05-menu/14-get-all-text-but-strip-html/docs/recursive.data.js
+++ b/packages/engine/test-node/fixtures/05-menu/14-get-all-text-but-strip-html/docs/recursive.data.js
@@ -1,0 +1,18 @@
+import { PageTree, SiteMenu } from '@rocket/engine';
+import { html } from 'lit';
+
+const pageTree = new PageTree({
+  inputDir: new URL('./', import.meta.url),
+  outputDir: new URL('../__output', import.meta.url),
+});
+
+await pageTree.restore();
+
+export const layout = data => {
+  return html`
+    ${pageTree.renderMenu(new SiteMenu(), data.sourceRelativeFilePath)}
+    <main>${data.content()}</main>
+  `;
+};
+
+export { html };

--- a/packages/engine/test-node/fixtures/05-menu/15-md-special-characters/docs/component.rocket.md
+++ b/packages/engine/test-node/fixtures/05-menu/15-md-special-characters/docs/component.rocket.md
@@ -1,0 +1,9 @@
+```js server
+/* START - Rocket auto generated - do not touch */
+export const sourceRelativeFilePath = 'component.rocket.md';
+import { layout, html } from './recursive.data.js';
+export { layout, html };
+/* END - Rocket auto generated - do not touch */
+```
+
+# &lt;some-button>

--- a/packages/engine/test-node/fixtures/05-menu/15-md-special-characters/docs/index.rocket.md
+++ b/packages/engine/test-node/fixtures/05-menu/15-md-special-characters/docs/index.rocket.md
@@ -1,0 +1,9 @@
+```js server
+/* START - Rocket auto generated - do not touch */
+export const sourceRelativeFilePath = 'index.rocket.md';
+import { layout, html } from './recursive.data.js';
+export { layout, html };
+/* END - Rocket auto generated - do not touch */
+```
+
+# Fun Errors & Feedback

--- a/packages/engine/test-node/fixtures/05-menu/15-md-special-characters/docs/pageTreeData.rocketGenerated.json
+++ b/packages/engine/test-node/fixtures/05-menu/15-md-special-characters/docs/pageTreeData.rocketGenerated.json
@@ -1,0 +1,34 @@
+{
+  "h1": "Fun Errors & Feedback",
+  "headlinesWithId": [
+    {
+      "text": "Fun Errors & Feedback",
+      "id": "fun-errors--feedback",
+      "level": 1
+    }
+  ],
+  "name": "Fun Errors & Feedback",
+  "menuLinkText": "Fun Errors & Feedback",
+  "url": "/",
+  "outputRelativeFilePath": "index.html",
+  "sourceRelativeFilePath": "index.rocket.md",
+  "level": 0,
+  "children": [
+    {
+      "h1": "&lt;some-button>",
+      "headlinesWithId": [
+        {
+          "text": "&lt;some-button>",
+          "id": "some-button",
+          "level": 1
+        }
+      ],
+      "name": "&lt;some-button>",
+      "menuLinkText": "&lt;some-button>",
+      "url": "/component/",
+      "outputRelativeFilePath": "component/index.html",
+      "sourceRelativeFilePath": "component.rocket.md",
+      "level": 1
+    }
+  ]
+}

--- a/packages/engine/test-node/fixtures/05-menu/15-md-special-characters/docs/recursive.data.js
+++ b/packages/engine/test-node/fixtures/05-menu/15-md-special-characters/docs/recursive.data.js
@@ -1,0 +1,18 @@
+import { PageTree, SiteMenu } from '@rocket/engine';
+import { html } from 'lit';
+
+const pageTree = new PageTree({
+  inputDir: new URL('./', import.meta.url),
+  outputDir: new URL('../__output', import.meta.url),
+});
+
+await pageTree.restore();
+
+export const layout = data => {
+  return html`
+    ${pageTree.renderMenu(new SiteMenu(), data.sourceRelativeFilePath)}
+    <main>${data.content()}</main>
+  `;
+};
+
+export { html };

--- a/packages/engine/test-node/fixtures/05-menu/16-link-text-attribute/docs/index.rocket.js
+++ b/packages/engine/test-node/fixtures/05-menu/16-link-text-attribute/docs/index.rocket.js
@@ -1,0 +1,11 @@
+/* START - Rocket auto generated - do not touch */
+export const sourceRelativeFilePath = 'index.rocket.js';
+import { layout, html } from './recursive.data.js';
+export { layout, html };
+/* END - Rocket auto generated - do not touch */
+
+export default () => html`
+  <h1 id="home" link-text="Home">Welcome to Rocket</h1>
+  <h2 id="first">First</h2>
+  <h2 link-text="Second" id="second">Second is best</h2>
+`;

--- a/packages/engine/test-node/fixtures/05-menu/16-link-text-attribute/docs/pageTreeData.rocketGenerated.json
+++ b/packages/engine/test-node/fixtures/05-menu/16-link-text-attribute/docs/pageTreeData.rocketGenerated.json
@@ -1,0 +1,28 @@
+{
+  "h1": "Home",
+  "headlinesWithId": [
+    {
+      "text": "Home",
+      "id": "home",
+      "level": 1,
+      "rawText": "Welcome to Rocket"
+    },
+    {
+      "text": "First",
+      "id": "first",
+      "level": 2
+    },
+    {
+      "text": "Second",
+      "id": "second",
+      "level": 2,
+      "rawText": "Second is best"
+    }
+  ],
+  "name": "Home",
+  "menuLinkText": "Home",
+  "url": "/",
+  "outputRelativeFilePath": "index.html",
+  "sourceRelativeFilePath": "index.rocket.js",
+  "level": 0
+}

--- a/packages/engine/test-node/fixtures/05-menu/16-link-text-attribute/docs/recursive.data.js
+++ b/packages/engine/test-node/fixtures/05-menu/16-link-text-attribute/docs/recursive.data.js
@@ -1,0 +1,18 @@
+import { PageTree, SiteMenu } from '@rocket/engine';
+import { html } from 'lit';
+
+const pageTree = new PageTree({
+  inputDir: new URL('./', import.meta.url),
+  outputDir: new URL('../__output', import.meta.url),
+});
+
+await pageTree.restore();
+
+export const layout = data => {
+  return html`
+    ${pageTree.renderMenu(new SiteMenu(), data.sourceRelativeFilePath)}
+    <main>${data.content()}</main>
+  `;
+};
+
+export { html };

--- a/site/pages/10--docs/20--basics/70--navigation.rocket.md
+++ b/site/pages/10--docs/20--basics/70--navigation.rocket.md
@@ -85,22 +85,22 @@ In most cases you probably will not need to do anything as it will take the text
 So if you have a page like this:
 
 ```md
-# Hello World
+# Learning Rocket
 ```
 
-then it will be called "Hello World" in the menu.
+then it will be called "Learning Rocket" in the menu.
 
 You can overwrite that by using the property `menuLinkText`;
 
 ````md
 ```js server
-export const menuLinkText = 'Hello';
+export const menuLinkText = 'Docs';
 ```
 
-# Hello World
+# Learning Rocket
 ````
 
-Now the menu will be called "Hello".
+Now the menu will be called "Docs".
 
 Within a menu the text of the links is defined by the following priority:
 
@@ -110,6 +110,23 @@ Within a menu the text of the links is defined by the following priority:
 4. sourceRelativeFilePath => fallback if no other option is available
 
 You can influence that data that gets provided to the menu by setting exports.
+
+### link-text="..."
+
+If you want to rename the menu text you can use the attribute `link-text`.
+It works on your h1 for the page title as well as on your h2-h6 for a table of contents menu.
+
+Examples:
+
+```html
+<h1 link-text="Docs">Learning Rocket</h1>
+
+<h2 link-text="Contact">Write us a message</h2>
+```
+
+<inline-notification>
+  You can use HTML within markdown too!
+</inline-notification>
 
 ## Headings with HTML
 

--- a/site/pages/10--docs/20--basics/70--navigation.rocket.md
+++ b/site/pages/10--docs/20--basics/70--navigation.rocket.md
@@ -111,6 +111,15 @@ Within a menu the text of the links is defined by the following priority:
 
 You can influence that data that gets provided to the menu by setting exports.
 
+## Headings with HTML
+
+HTML in headings will be ignored for the menu
+
+Some examples:
+
+- `<h1>Hello <em>Word</em></h1>` => `Hello Word`
+- `<h1>Hello <strong>World</strong> of <span>JS <em>(JavaScript)</em></span>!</h1>` => `Hello World of JS (JavaScript)!`
+
 ## Menu No Link
 
 Often you have sections or groups of pages which you want to provide a heading for.


### PR DESCRIPTION
## What I did

1. Make sure the most common use cases for menu renaming are supported


closes https://github.com/modernweb-dev/rocket/issues/236