### PR TITLE
docs: correct path of examples link.

### DIFF
--- a/site/pages/10--docs/10--setup/10--getting-started.rocket.md
+++ b/site/pages/10--docs/10--setup/10--getting-started.rocket.md
@@ -54,7 +54,7 @@ Like any unfamiliar technology, Rocket comes with a slight learning curve. Howev
 
 ### Example Projects
 
-If you prefer to learn Rocket by example, check out our [examples](https://github.com/modernweb-dev/rocket/tree/next/examples) on GitHub.
+If you prefer to learn Rocket by example, check out our [examples](https://github.com/modernweb-dev/rocket/tree/main/examples) on GitHub.
 
 You locally install any of these examples by running `npx @rocket/create@latest` and selecting it within the wizard.
 


### PR DESCRIPTION
## What I did

1. Corrected the path of the examples link.
