### PR TITLE
fix(engine): support fragments when adjusting urls

### DIFF
--- a/.changeset/fluffy-impalas-mix.md
+++ b/.changeset/fluffy-impalas-mix.md
@@ -1,0 +1,16 @@
+---
+'@rocket/engine': patch
+---
+
+Adjust urls containing url fragments
+
+```html
+<!-- user writes -->
+<a href="./about.rocket.js#some-id"></a>
+
+<!-- rocket outputs -->
+<!-- before -->
+<a href="./about.rocket.js#some-id"></a>
+<!-- after -->
+<a href="/about/#some-id"></a>
+```

--- a/packages/engine/test-node/test-helpers.js
+++ b/packages/engine/test-node/test-helpers.js
@@ -13,6 +13,17 @@ const { expect } = chai;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Expect a throw in an async function
+ *
+ * @example
+ *   await expectThrowsAsync(() => myAsyncFunction(), {
+ *     errorMatch: /exact throw message/,
+ *   });
+ * @example
+ *   await expectThrowsAsync(() => myAsyncFunction(), {
+ *     errorMatch: /check throw message with a regex/,
+ *   });
+ *
  * @param {function} method
  * @param {string} errorMessage
  */

--- a/site/pages/30--tools/30--rollup-config/10--overview.rocket.md
+++ b/site/pages/30--tools/30--rollup-config/10--overview.rocket.md
@@ -81,7 +81,7 @@ You write modern JavaScript using the latest browser features. Rollup will optim
 
 Our config sets you up with good defaults for most projects. Additionally you can add more plugins and adjust predefined plugins or even remove them if needed.
 
-We use the [plugins-manager](./plugins-manager.md) for it.
+We use the [plugins-manager](../10--plugins-manager/10--overview.rocket.md) for it.
 
 ### Customizing the Babel Config
 
@@ -112,7 +112,7 @@ SPA and MPA plugins:
 - [polyfills-loader](https://modern-web.dev/docs/building/rollup-plugin-polyfills-loader/)
 - [workbox](https://www.npmjs.com/package/rollup-plugin-workbox)
 
-You can customize options for these plugins by using [adjustPluginOptions](./plugins-manager.md#adjusting-plugin-options).
+You can customize options for these plugins by using [adjustPluginOptions](../10--plugins-manager/10--overview.rocket.md#adjusting-plugin-options).
 
 ```js
 import { createSpaConfig } from '@rocket/building-rollup';


### PR DESCRIPTION
## What I did

1. Adjust urls containing url fragments

```html
<!-- user writes -->
<a href="./about.rocket.js#some-id"></a>

<!-- rocket outputs -->
<!-- before -->
<a href="./about.rocket.js#some-id"></a>
<!-- after -->
<a href="/about/#some-id"></a>
```
