### PR TITLE
fix for showcases overlapping the nav bar.

### DIFF
--- a/src/RocketJsDemo.js
+++ b/src/RocketJsDemo.js
@@ -250,6 +250,7 @@ export class RocketJsDemo extends LitElement {
         background-color: #eee;
         width: 100%;
         overflow: hidden;
+        z-index: 0;
       }
 
       #resize {


### PR DESCRIPTION
fixed overlapping of components that were using z-indexes in the showcase with the nav bar by overwriting said z-index for the entire showcases. the stacking order inside of the component should stay the same

## What I did

1. set the z-index for the div containing the showcase to 0, overwriting the z-inxed defined by the componements below. The stacking inside of the component should be unaffected
